### PR TITLE
fix: add Adapter alias + reorder RESOLUTION_ORDER (anthropic first)

### DIFF
--- a/adapter.py
+++ b/adapter.py
@@ -74,3 +74,7 @@ class HermesAdapter(BaseAdapter):
 
         executor._heartbeat = config.heartbeat
         return executor
+
+# Module-level alias so molecule-runtime's ADAPTER_MODULE=adapter resolves Adapter via 'import adapter'.
+# Without this the runtime's get_adapter() fails to find the class and falls through to discovery.
+Adapter = HermesAdapter

--- a/providers.py
+++ b/providers.py
@@ -222,11 +222,17 @@ PROVIDERS: dict[str, ProviderConfig] = {
 # followed by the most likely-to-be-configured commercial APIs.
 
 RESOLUTION_ORDER: tuple[str, ...] = (
-    # Back-compat: PR 2 baseline
+    # Anthropic first — Molecule AI default preference is Claude (CEO directive
+    # 2026-04-16 'I prefer claude but we should be able to support all'). When
+    # ANTHROPIC_API_KEY is set, hermes resolves to Claude via the native
+    # Messages API. Other providers stay registered + resolvable via explicit
+    # provider= kwarg or via their own env var when ANTHROPIC_API_KEY is unset.
+    "anthropic",
+    # PR 2 back-compat — nous_portal + openrouter still resolve when their
+    # env vars are set + ANTHROPIC_API_KEY is not.
     "nous_portal",
     "openrouter",
     # Frontier commercial
-    "anthropic",
     "openai",
     "gemini",
     "xai",


### PR DESCRIPTION
## Summary
Two issues blocking Hermes:

1. **Adapter alias missing** — `molecule-runtime` does `import adapter; getattr(mod, 'Adapter')`. The class is `HermesAdapter`, no module-level `Adapter` symbol. Without this the runtime fails with `KeyError: "Unknown runtime 'hermes'. Available: "`. Same bug that bit claude-code-default earlier today; same one-line fix.

2. **Anthropic first in auto-detect** — per CEO directive 2026-04-16 ("I prefer claude but we should be able to support all"). When `ANTHROPIC_API_KEY` is set, Hermes resolves to Claude via the native Messages API. Other 14 providers still registered + resolvable via explicit `provider=` or own env var when ANTHROPIC_API_KEY is unset.

## Test plan
- [x] `import adapter; adapter.Adapter` returns `HermesAdapter`
- [x] `adapter.Adapter.name()` returns `'hermes'`
- [x] `providers.RESOLUTION_ORDER[:3]` returns `('anthropic', 'nous_portal', 'openrouter')`
- [x] `len(providers.PROVIDERS)` returns 15 (no providers dropped)

🤖 Generated with [Claude Code](https://claude.com/claude-code)