### PR TITLE
fix: bridge OPENAI_API_KEY → custom provider when only OpenAI key set

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -121,6 +121,20 @@ chmod 600 "$HERMES_HOME/.env"
 DEFAULT_MODEL="${HERMES_DEFAULT_MODEL:-nousresearch/hermes-4-70b}"
 HERMES_DEFAULT_MODEL="${DEFAULT_MODEL}" \
   . "$(dirname "$0")/scripts/derive-provider.sh"
+
+# Auto-bridge OPENAI_API_KEY → "custom" provider against api.openai.com
+# when derive-provider picked "custom" via the openai/* slug path
+# (fires only when OPENAI_API_KEY is set but OPENROUTER_API_KEY is not —
+# see scripts/derive-provider.sh). Without this, PROVIDER=custom would
+# write an empty base_url/api_key stanza and hermes would fail on first
+# call. HERMES_CUSTOM_* env vars still win when the operator set them
+# explicitly; we only fill missing values.
+if [ "${PROVIDER}" = "custom" ] && [ -n "${OPENAI_API_KEY:-}" ] && [ -z "${HERMES_CUSTOM_BASE_URL:-}" ] && [ -z "${HERMES_CUSTOM_API_KEY:-}" ]; then
+  export HERMES_CUSTOM_BASE_URL="https://api.openai.com/v1"
+  export HERMES_CUSTOM_API_KEY="${OPENAI_API_KEY}"
+  echo "[install.sh] bridged OPENAI_API_KEY → custom provider @ api.openai.com"
+fi
+
 {
   echo "# Seeded by template-hermes install.sh on $(date -u -Iseconds)"
   echo "# Rewritten each boot from HERMES_DEFAULT_MODEL + HERMES_INFERENCE_PROVIDER env."

--- a/scripts/derive-provider.sh
+++ b/scripts/derive-provider.sh
@@ -59,8 +59,26 @@ case "${HERMES_DEFAULT_MODEL}" in
   opencode-zen/*)          PROVIDER="opencode-zen" ;;
   opencode-go/*)           PROVIDER="opencode-go" ;;
 
-  # Hermes-specific routing quirks
-  openai/*)                PROVIDER="openrouter" ;;  # no direct openai provider; openrouter covers it
+  # Hermes-specific routing quirks. `openai/*` has two valid targets:
+  #   1. OpenRouter (hermes's built-in path — requires OPENROUTER_API_KEY).
+  #   2. hermes's "custom" provider pointed at api.openai.com — requires
+  #      OPENAI_API_KEY. install.sh sees this case and auto-populates
+  #      HERMES_CUSTOM_{BASE_URL,API_KEY} so the direct-OpenAI path works
+  #      without the user having to set HERMES_CUSTOM_* explicitly.
+  # Prefer OR when an OR key is present (keeps existing installs stable).
+  # Fall through to custom when only an OpenAI key is available — the
+  # operator expectation for a workspace whose sole credential is
+  # OPENAI_API_KEY is that hermes should call OpenAI directly, not fail
+  # on "missing OPENROUTER_API_KEY". Matches the 2026-04-23 E2E case.
+  openai/*)
+    if [ -n "${OPENROUTER_API_KEY:-}" ]; then
+      PROVIDER="openrouter"
+    elif [ -n "${OPENAI_API_KEY:-}" ]; then
+      PROVIDER="custom"
+    else
+      PROVIDER="openrouter" # no-key fallback — hermes will error clearly
+    fi
+    ;;
   nousresearch/*)
     # Prefer direct Nous Portal if Nous credentials present, else OR.
     if [ -n "${HERMES_API_KEY:-}" ] || [ -n "${NOUS_API_KEY:-}" ]; then

--- a/start.sh
+++ b/start.sh
@@ -102,6 +102,17 @@ DEFAULT_MODEL="${HERMES_DEFAULT_MODEL:-nousresearch/hermes-4-70b}"
 DERIVE_SCRIPT="/app/scripts/derive-provider.sh"
 [ -f "$DERIVE_SCRIPT" ] || DERIVE_SCRIPT="/scripts/derive-provider.sh"
 HERMES_DEFAULT_MODEL="${DEFAULT_MODEL}" . "$DERIVE_SCRIPT"
+
+# Auto-bridge OPENAI_API_KEY → "custom" provider against api.openai.com
+# when derive-provider picked "custom" via the openai/* slug path.
+# Kept in sync with install.sh so Docker + bare-host paths behave
+# identically. HERMES_CUSTOM_* env vars win when explicitly set.
+if [ "${PROVIDER}" = "custom" ] && [ -n "${OPENAI_API_KEY:-}" ] && [ -z "${HERMES_CUSTOM_BASE_URL:-}" ] && [ -z "${HERMES_CUSTOM_API_KEY:-}" ]; then
+  export HERMES_CUSTOM_BASE_URL="https://api.openai.com/v1"
+  export HERMES_CUSTOM_API_KEY="${OPENAI_API_KEY}"
+  echo "[start.sh] bridged OPENAI_API_KEY → custom provider @ api.openai.com"
+fi
+
 {
   echo "# Seeded by molecule template-hermes start.sh. Customize via"
   echo "# \`hermes config edit\` or by editing this file directly."


### PR DESCRIPTION
## Summary
Closes the "OpenAI key only → hermes 401 at first A2A" gap hit by staging E2E and any operator whose sole credential is an OpenAI API key.

Hermes-agent upstream has no direct \`openai\` LLM provider (its \`.env.example\` literally says *\"All LLM calls go through OpenRouter\"*). Our derive-provider.sh followed that: \`openai/*\` → \`openrouter\` always. Workspaces with only \`OPENAI_API_KEY\` (no OpenRouter subscription) failed at the first A2A turn because OpenRouter rejected the OpenAI key.

## Fix
Hermes exposes a \`custom\` provider with \`base_url\` + \`api_key\` overrides (already plumbed via \`HERMES_CUSTOM_*\` env vars). Teach the template to auto-populate that bridge when only an OpenAI key is present:

- **scripts/derive-provider.sh** — \`openai/*\` routing becomes:
  - \`openrouter\` when \`OPENROUTER_API_KEY\` set (unchanged path)
  - \`custom\`     when only \`OPENAI_API_KEY\` set (new path)
  - \`openrouter\` as a no-key fallback (clear error at call time)
- **install.sh + start.sh** — when provider is \`custom\` and \`HERMES_CUSTOM_*\` not explicitly set but \`OPENAI_API_KEY\` is, auto-set:
  - \`HERMES_CUSTOM_BASE_URL=https://api.openai.com/v1\`
  - \`HERMES_CUSTOM_API_KEY=\$OPENAI_API_KEY\`

The config.yaml stanza picks these up verbatim — hermes calls OpenAI directly.

## Verified
| Scenario | Result |
|---|---|
| \`OPENAI_API_KEY\` only, slug \`openai/gpt-4o\` | PROVIDER=custom, bridge fires ✅ |
| \`OPENROUTER_API_KEY\` set (OR + OpenAI or OR alone) | PROVIDER=openrouter (unchanged) ✅ |
| No keys | PROVIDER=openrouter fallback (clear 401 from OR) ✅ |
| \`HERMES_CUSTOM_*\` set explicitly | No bridge, operator config honored ✅ |

\`bash -n\` on all three scripts passes. Existing operators unaffected.

## Context
2026-04-23 E2E Staging SaaS was hitting this bug — reached step 8/11 (A2A) for the first time after \`molecule-controlplane#236\` deployed the install.sh hook, then 401'd because staging CI only carries \`MOLECULE_STAGING_OPENAI_KEY\`. After this PR lands, that path works end-to-end.

## Deploy
Template repo is pulled by workspace user-data via \`git clone --depth 1\`. The fix applies to every newly-provisioned workspace on next merge; existing running workspaces need a restart to pick up the new \`install.sh\`.