### PR TITLE
chore: promote staging → main (openai-direct-provider fix)

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -121,6 +121,20 @@ chmod 600 "$HERMES_HOME/.env"
 DEFAULT_MODEL="${HERMES_DEFAULT_MODEL:-nousresearch/hermes-4-70b}"
 HERMES_DEFAULT_MODEL="${DEFAULT_MODEL}" \
   . "$(dirname "$0")/scripts/derive-provider.sh"
+
+# Auto-bridge OPENAI_API_KEY → "custom" provider against api.openai.com
+# when derive-provider picked "custom" via the openai/* slug path
+# (fires only when OPENAI_API_KEY is set but OPENROUTER_API_KEY is not —
+# see scripts/derive-provider.sh). Without this, PROVIDER=custom would
+# write an empty base_url/api_key stanza and hermes would fail on first
+# call. HERMES_CUSTOM_* env vars still win when the operator set them
+# explicitly; we only fill missing values.
+if [ "${PROVIDER}" = "custom" ] && [ -n "${OPENAI_API_KEY:-}" ] && [ -z "${HERMES_CUSTOM_BASE_URL:-}" ] && [ -z "${HERMES_CUSTOM_API_KEY:-}" ]; then
+  export HERMES_CUSTOM_BASE_URL="https://api.openai.com/v1"
+  export HERMES_CUSTOM_API_KEY="${OPENAI_API_KEY}"
+  echo "[install.sh] bridged OPENAI_API_KEY → custom provider @ api.openai.com"
+fi
+
 {
   echo "# Seeded by template-hermes install.sh on $(date -u -Iseconds)"
   echo "# Rewritten each boot from HERMES_DEFAULT_MODEL + HERMES_INFERENCE_PROVIDER env."

--- a/scripts/derive-provider.sh
+++ b/scripts/derive-provider.sh
@@ -59,8 +59,26 @@ case "${HERMES_DEFAULT_MODEL}" in
   opencode-zen/*)          PROVIDER="opencode-zen" ;;
   opencode-go/*)           PROVIDER="opencode-go" ;;
 
-  # Hermes-specific routing quirks
-  openai/*)                PROVIDER="openrouter" ;;  # no direct openai provider; openrouter covers it
+  # Hermes-specific routing quirks. `openai/*` has two valid targets:
+  #   1. OpenRouter (hermes's built-in path — requires OPENROUTER_API_KEY).
+  #   2. hermes's "custom" provider pointed at api.openai.com — requires
+  #      OPENAI_API_KEY. install.sh sees this case and auto-populates
+  #      HERMES_CUSTOM_{BASE_URL,API_KEY} so the direct-OpenAI path works
+  #      without the user having to set HERMES_CUSTOM_* explicitly.
+  # Prefer OR when an OR key is present (keeps existing installs stable).
+  # Fall through to custom when only an OpenAI key is available — the
+  # operator expectation for a workspace whose sole credential is
+  # OPENAI_API_KEY is that hermes should call OpenAI directly, not fail
+  # on "missing OPENROUTER_API_KEY". Matches the 2026-04-23 E2E case.
+  openai/*)
+    if [ -n "${OPENROUTER_API_KEY:-}" ]; then
+      PROVIDER="openrouter"
+    elif [ -n "${OPENAI_API_KEY:-}" ]; then
+      PROVIDER="custom"
+    else
+      PROVIDER="openrouter" # no-key fallback — hermes will error clearly
+    fi
+    ;;
   nousresearch/*)
     # Prefer direct Nous Portal if Nous credentials present, else OR.
     if [ -n "${HERMES_API_KEY:-}" ] || [ -n "${NOUS_API_KEY:-}" ]; then

--- a/start.sh
+++ b/start.sh
@@ -102,6 +102,17 @@ DEFAULT_MODEL="${HERMES_DEFAULT_MODEL:-nousresearch/hermes-4-70b}"
 DERIVE_SCRIPT="/app/scripts/derive-provider.sh"
 [ -f "$DERIVE_SCRIPT" ] || DERIVE_SCRIPT="/scripts/derive-provider.sh"
 HERMES_DEFAULT_MODEL="${DEFAULT_MODEL}" . "$DERIVE_SCRIPT"
+
+# Auto-bridge OPENAI_API_KEY → "custom" provider against api.openai.com
+# when derive-provider picked "custom" via the openai/* slug path.
+# Kept in sync with install.sh so Docker + bare-host paths behave
+# identically. HERMES_CUSTOM_* env vars win when explicitly set.
+if [ "${PROVIDER}" = "custom" ] && [ -n "${OPENAI_API_KEY:-}" ] && [ -z "${HERMES_CUSTOM_BASE_URL:-}" ] && [ -z "${HERMES_CUSTOM_API_KEY:-}" ]; then
+  export HERMES_CUSTOM_BASE_URL="https://api.openai.com/v1"
+  export HERMES_CUSTOM_API_KEY="${OPENAI_API_KEY}"
+  echo "[start.sh] bridged OPENAI_API_KEY → custom provider @ api.openai.com"
+fi
+
 {
   echo "# Seeded by molecule template-hermes start.sh. Customize via"
   echo "# \`hermes config edit\` or by editing this file directly."


### PR DESCRIPTION
## Summary
Promotes staging → main so newly-provisioned workspaces clone the **openai-direct-provider bridge** (PR #10). Without this, any workspace whose sole credential is an OpenAI API key hits \`[hermes-agent error 401] Invalid API key\` on the first A2A message — hermes routes \`openai/*\` models through OpenRouter, which rejects the OpenAI key.

## Commits
- \`a1d933a\` Merge #10
- \`6c55ee0\` fix: bridge OPENAI_API_KEY → custom provider when only OpenAI key set

## Impact
Workspace EC2 user-data does \`git clone --depth 1\` from this repo's default branch (\`main\`). Once promoted:
- New hermes workspaces with \`OPENAI_API_KEY\` + \`openai/*\` model slug boot straight to a working \`custom\` provider pointed at api.openai.com
- Existing workspaces pick up the fix on their next Save & Restart (re-clone)
- Operators who have explicitly set \`HERMES_CUSTOM_*\` or \`OPENROUTER_API_KEY\` are unchanged

## Context
Unblocks prod user workspace stuck in "online + 401" loop today. Also unblocks E2E Staging SaaS (step 8/11 hermes A2A call).

🤖 Generated with [Claude Code](https://claude.com/claude-code)