### PR TITLE
chore: promote staging → main (hermes api_mode=chat_completions correct fix)

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -154,32 +154,38 @@ DEFAULT_MODEL="${HERMES_DEFAULT_MODEL:-nousresearch/hermes-4-70b}"
 HERMES_DEFAULT_MODEL="${DEFAULT_MODEL}" \
   . "$(dirname "$0")/scripts/derive-provider.sh"
 
-# --- FIXES #13 + #14: OpenAI bridge uses native openai provider ---
+# --- OpenAI bridge: PROVIDER=custom + chat_completions api_mode ---
 #
-# Previously this block bridged OPENAI_API_KEY → custom provider. That
-# caused TWO downstream bugs:
+# hermes-agent does NOT have a native "openai" provider in its registry
+# (valid list includes: ai-gateway, anthropic, openrouter, nous, custom,
+# minimax, kimi, etc — but NOT "openai"). See `hermes doctor` output for
+# the authoritative list. Therefore the OpenAI bridge uses `custom`
+# provider pointed at api.openai.com.
 #
-#   #13: custom provider passes model slug verbatim → OpenAI sees
-#        `openai/gpt-4o` and returns 400 model_not_found (expects `gpt-4o`).
-#        Fix: strip the `openai/` prefix from DEFAULT_MODEL here.
+# Three things have to line up for this to actually work:
 #
-#   #14: custom provider's /v1/responses code path sends
-#        include=[reasoning.encrypted_content] which only o1-family
-#        models support. Switching to native openai provider routes
-#        the request through the model-family-aware code path that
-#        chooses /v1/chat/completions for gpt-* and /v1/responses
-#        for o1/o3/o4 + conditionally adds encrypted_content.
+#   (1) Keep PROVIDER=custom when only OPENAI_API_KEY is set. Setting
+#       PROVIDER=openai crashes the gateway with "Unknown provider".
 #
-# Resolution: when only OPENAI_API_KEY is provided (no OPENROUTER,
-# no explicit HERMES_CUSTOM_*), set PROVIDER=openai (hermes has a
-# native openai provider) and strip the slug prefix. Custom remains
-# available when the operator explicitly configures HERMES_CUSTOM_*
-# (e.g. pointing at a self-hosted vLLM endpoint).
+#   (2) Strip the `openai/` prefix from DEFAULT_MODEL. Custom passes
+#       the model name verbatim to the endpoint; OpenAI rejects
+#       `openai/gpt-4o` with 400 model_not_found (expects `gpt-4o`).
+#
+#   (3) Set api_mode: "chat_completions" in the emitted config.yaml.
+#       Without this, hermes defaults custom provider to codex_responses
+#       which hits /v1/responses + sends include=[reasoning.encrypted_content].
+#       gpt-4o / gpt-4.1 reject that with 400 (only o1 family supports it).
+#
+# Fires ONLY when operator hasn't configured HERMES_CUSTOM_* themselves —
+# explicit custom endpoints (vLLM, LM Studio) skip the prefix strip and
+# chat_completions default.
 if [ "${PROVIDER}" = "custom" ] && [ -n "${OPENAI_API_KEY:-}" ] && [ -z "${HERMES_CUSTOM_BASE_URL:-}" ] && [ -z "${HERMES_CUSTOM_API_KEY:-}" ]; then
-  PROVIDER="openai"
-  # Strip `openai/` prefix so OpenAI sees a plain model name.
+  export HERMES_CUSTOM_BASE_URL="https://api.openai.com/v1"
+  export HERMES_CUSTOM_API_KEY="${OPENAI_API_KEY}"
+  export HERMES_CUSTOM_API_MODE="chat_completions"
+  # Strip the `openai/` provider prefix — OpenAI expects bare model names.
   DEFAULT_MODEL="${DEFAULT_MODEL#openai/}"
-  echo "[install.sh] bridged OPENAI_API_KEY → native openai provider, model=${DEFAULT_MODEL}"
+  echo "[install.sh] bridged OPENAI_API_KEY → custom provider @ api.openai.com (api_mode=chat_completions, model=${DEFAULT_MODEL})"
 fi
 
 {
@@ -193,6 +199,13 @@ fi
   fi
   if [ -n "${HERMES_CUSTOM_API_KEY:-}" ]; then
     echo "  api_key: \"${HERMES_CUSTOM_API_KEY}\""
+  fi
+  # api_mode gates hermes's custom-provider request shape:
+  #   chat_completions  → POST /v1/chat/completions (OpenAI-compat, default)
+  #   codex_responses   → POST /v1/responses + include=[encrypted_content]
+  # Emit the field only when explicitly set — absent = hermes auto-detect.
+  if [ -n "${HERMES_CUSTOM_API_MODE:-}" ]; then
+    echo "  api_mode: \"${HERMES_CUSTOM_API_MODE}\""
   fi
 } >"$HERMES_HOME/config.yaml"
 

--- a/start.sh
+++ b/start.sh
@@ -103,17 +103,17 @@ DERIVE_SCRIPT="/app/scripts/derive-provider.sh"
 [ -f "$DERIVE_SCRIPT" ] || DERIVE_SCRIPT="/scripts/derive-provider.sh"
 HERMES_DEFAULT_MODEL="${DEFAULT_MODEL}" . "$DERIVE_SCRIPT"
 
-# --- FIXES #13 + #14: use native openai provider for OpenAI bridge ---
-# Symmetric with install.sh. Custom provider path was broken on OpenAI:
-#   - passes full slug (openai/gpt-4o) → 400 model_not_found
-#   - sends include=[reasoning.encrypted_content] → 400 on non-o1 models
-# Native openai provider strips the prefix and routes through the
-# model-family-aware code path. Explicit HERMES_CUSTOM_* still wins
-# when the operator configures a genuine custom endpoint (e.g. vLLM).
+# --- OpenAI bridge: custom provider + chat_completions api_mode ---
+# Symmetric with install.sh. See install.sh for the full explanation.
+# hermes has NO native "openai" provider — bridge must use custom+
+# api_mode=chat_completions to get the OpenAI-compat /v1/chat/completions
+# path (not /v1/responses with encrypted_content, which 400s on gpt-4o).
 if [ "${PROVIDER}" = "custom" ] && [ -n "${OPENAI_API_KEY:-}" ] && [ -z "${HERMES_CUSTOM_BASE_URL:-}" ] && [ -z "${HERMES_CUSTOM_API_KEY:-}" ]; then
-  PROVIDER="openai"
+  export HERMES_CUSTOM_BASE_URL="https://api.openai.com/v1"
+  export HERMES_CUSTOM_API_KEY="${OPENAI_API_KEY}"
+  export HERMES_CUSTOM_API_MODE="chat_completions"
   DEFAULT_MODEL="${DEFAULT_MODEL#openai/}"
-  echo "[start.sh] bridged OPENAI_API_KEY → native openai provider, model=${DEFAULT_MODEL}"
+  echo "[start.sh] bridged OPENAI_API_KEY → custom provider @ api.openai.com (api_mode=chat_completions, model=${DEFAULT_MODEL})"
 fi
 
 {
@@ -133,6 +133,12 @@ fi
   fi
   if [ -n "${HERMES_CUSTOM_API_KEY:-}" ]; then
     echo "  api_key: \"${HERMES_CUSTOM_API_KEY}\""
+  fi
+  # api_mode gates hermes custom-provider request shape:
+  #   chat_completions  → /v1/chat/completions (OpenAI-compat)
+  #   codex_responses   → /v1/responses + encrypted_content (o1 only)
+  if [ -n "${HERMES_CUSTOM_API_MODE:-}" ]; then
+    echo "  api_mode: \"${HERMES_CUSTOM_API_MODE}\""
   fi
 } >"$HERMES_CONFIG"
 chown agent:agent "$HERMES_CONFIG"


### PR DESCRIPTION
## Summary

Promotes [#17](https://github.com/Molecule-AI/molecule-ai-workspace-template-hermes/pull/17) from staging → main.

## What this does on main

Replaces the buggy #16 direction (PROVIDER=openai — crashed gateway with "Unknown provider 'openai'") with the correct shape:

- Keep `PROVIDER=custom` (only OpenAI-compat path in hermes's registry)
- Strip `openai/` prefix from model slug → OpenAI sees `gpt-4o` not `openai/gpt-4o`
- Set `api_mode: chat_completions` → hermes uses /v1/chat/completions (the OpenAI standard endpoint), NOT /v1/responses with encrypted_content

## Validation

Live-validated end-to-end on user's `hongmingwang` tenant at 21:31Z:
- Patched config.yaml to the shape this PR will produce
- Started hermes gateway via systemd-run
- POSTed A2A JSON-RPC 2.0 with "say hello in 5 words" prompt
- **Got real GPT response: "Hello there, nice to meet you!"**

Evidence in PR #17 body + this session's logs.

## Post-merge

After this merges:
1. publish-image workflow rebuilds the template Docker image + syncs install.sh for EC2 user-data
2. New workspaces provisioned from canvas will use the correct install.sh
3. Existing workspaces (e.g. user's WS_ID 6a7608dd) won't auto-update — they need a terminate+reprovision to pick up the new install.sh. User either deletes + creates fresh workspace in canvas, OR I force-terminate the EC2 so CP provisions a fresh one from main.

## CEO approval required per branching policy