### PR TITLE
fix(derive-provider): prefer custom (direct OpenAI) when OPENAI_API_KEY set for openai/* models

### DIFF
--- a/scripts/derive-provider.sh
+++ b/scripts/derive-provider.sh
@@ -60,21 +60,27 @@ case "${HERMES_DEFAULT_MODEL}" in
   opencode-go/*)           PROVIDER="opencode-go" ;;
 
   # Hermes-specific routing quirks. `openai/*` has two valid targets:
-  #   1. OpenRouter (hermes's built-in path — requires OPENROUTER_API_KEY).
-  #   2. hermes's "custom" provider pointed at api.openai.com — requires
+  #   1. hermes's "custom" provider pointed at api.openai.com — requires
   #      OPENAI_API_KEY. install.sh sees this case and auto-populates
   #      HERMES_CUSTOM_{BASE_URL,API_KEY} so the direct-OpenAI path works
   #      without the user having to set HERMES_CUSTOM_* explicitly.
-  # Prefer OR when an OR key is present (keeps existing installs stable).
-  # Fall through to custom when only an OpenAI key is available — the
-  # operator expectation for a workspace whose sole credential is
-  # OPENAI_API_KEY is that hermes should call OpenAI directly, not fail
-  # on "missing OPENROUTER_API_KEY". Matches the 2026-04-23 E2E case.
+  #   2. OpenRouter (hermes's built-in path — requires OPENROUTER_API_KEY).
+  #
+  # Priority: prefer **custom** (direct OpenAI) when OPENAI_API_KEY is set.
+  # The operator supplying OPENAI_API_KEY for an openai/* model is an
+  # explicit intent signal to hit OpenAI directly. The previous "prefer
+  # OR if any OR key exists" rule silently hijacked that intent whenever
+  # a tenant-global OPENROUTER_API_KEY was present (even if stale/empty
+  # enough to 401), which is exactly what bit the 2026-04-23 E2E (surfaced
+  # as OpenRouter's `401 Missing Authentication header` in the agent reply).
+  #
+  # To explicitly route openai/* through OR, set HERMES_INFERENCE_PROVIDER=openrouter
+  # (handled at the top of this file) or use an openrouter/* model slug.
   openai/*)
-    if [ -n "${OPENROUTER_API_KEY:-}" ]; then
-      PROVIDER="openrouter"
-    elif [ -n "${OPENAI_API_KEY:-}" ]; then
+    if [ -n "${OPENAI_API_KEY:-}" ]; then
       PROVIDER="custom"
+    elif [ -n "${OPENROUTER_API_KEY:-}" ]; then
+      PROVIDER="openrouter"
     else
       PROVIDER="openrouter" # no-key fallback — hermes will error clearly
     fi

--- a/scripts/test-derive-provider.sh
+++ b/scripts/test-derive-provider.sh
@@ -1,0 +1,112 @@
+#!/usr/bin/env bash
+# test-derive-provider.sh — offline unit tests for derive-provider.sh.
+#
+# derive-provider.sh has zero external deps (no network, no hermes install,
+# no filesystem writes) — it's pure env-var → PROVIDER string. That makes
+# it cheap to exercise in CI as a shell-level test: set env, source, check
+# $PROVIDER. Runs in <1s.
+#
+# Covers regressions:
+#   #19 (2026-04-23 E2E) — openai/* + OPENAI_API_KEY must route to `custom`,
+#       NOT `openrouter`, even when a global OPENROUTER_API_KEY is present.
+#       Previously the wrong-priority rule hijacked operator intent and the
+#       A2A reply surfaced OpenRouter's `401 Missing Authentication header`.
+
+set -u
+
+HERE="$(cd "$(dirname "$0")" && pwd)"
+SCRIPT="$HERE/derive-provider.sh"
+
+if [ ! -f "$SCRIPT" ]; then
+  echo "FAIL: derive-provider.sh not found at $SCRIPT"
+  exit 2
+fi
+
+PASS=0
+FAIL=0
+
+assert_provider() {
+  local label="$1" expected="$2"
+  # Run in subshell so env mutations don't leak between cases.
+  local actual
+  actual=$(bash -c "
+    unset HERMES_INFERENCE_PROVIDER
+    $3
+    PROVIDER=''
+    . '$SCRIPT'
+    echo \$PROVIDER
+  ")
+  if [ "$actual" = "$expected" ]; then
+    echo "  PASS  $label  →  $actual"
+    PASS=$((PASS+1))
+  else
+    echo "  FAIL  $label  →  got '$actual', expected '$expected'"
+    FAIL=$((FAIL+1))
+  fi
+}
+
+echo "== derive-provider.sh =="
+
+# --- explicit override wins ---
+assert_provider "HERMES_INFERENCE_PROVIDER=anthropic beats model slug" "anthropic" '
+  HERMES_INFERENCE_PROVIDER=anthropic
+  HERMES_DEFAULT_MODEL=openai/gpt-4o
+'
+
+# --- direct-SDK prefixes ---
+assert_provider "minimax/M2 → minimax" "minimax" '
+  HERMES_DEFAULT_MODEL=minimax/MiniMax-M2
+'
+assert_provider "anthropic/claude → anthropic" "anthropic" '
+  HERMES_DEFAULT_MODEL=anthropic/claude-sonnet-4-6
+'
+
+# --- openai/* priority: REGRESSION TEST for #19 / 2026-04-23 E2E ---
+# The scenario: operator provides OPENAI_API_KEY as a workspace secret,
+# and the CP/tenant has OPENROUTER_API_KEY set globally. derive-provider
+# must pick `custom` (direct OpenAI) to honor operator intent — NOT
+# `openrouter` which would hit OR with a key that may be stale/empty.
+assert_provider "openai/* + OPENAI_API_KEY + OPENROUTER_API_KEY → custom (#19 regression)" "custom" '
+  HERMES_DEFAULT_MODEL=openai/gpt-4o
+  export OPENAI_API_KEY=sk-test-openai
+  export OPENROUTER_API_KEY=sk-or-test
+'
+
+assert_provider "openai/* + only OPENAI_API_KEY → custom" "custom" '
+  HERMES_DEFAULT_MODEL=openai/gpt-4o
+  export OPENAI_API_KEY=sk-test-openai
+'
+
+assert_provider "openai/* + only OPENROUTER_API_KEY → openrouter" "openrouter" '
+  HERMES_DEFAULT_MODEL=openai/gpt-4o
+  export OPENROUTER_API_KEY=sk-or-test
+'
+
+assert_provider "openai/* + no keys → openrouter (fail-loud fallback)" "openrouter" '
+  HERMES_DEFAULT_MODEL=openai/gpt-4o
+'
+
+# --- nousresearch/* branches ---
+assert_provider "nousresearch/* + HERMES_API_KEY → nous" "nous" '
+  HERMES_DEFAULT_MODEL=nousresearch/hermes-4-70b
+  export HERMES_API_KEY=h-test
+'
+assert_provider "nousresearch/* + only NOUS_API_KEY → nous" "nous" '
+  HERMES_DEFAULT_MODEL=nousresearch/hermes-4-70b
+  export NOUS_API_KEY=n-test
+'
+assert_provider "nousresearch/* + no nous keys → openrouter" "openrouter" '
+  HERMES_DEFAULT_MODEL=nousresearch/hermes-4-70b
+'
+
+# --- unknown prefix ---
+assert_provider "unknown prefix → auto" "auto" '
+  HERMES_DEFAULT_MODEL=vendor-x/model-y
+'
+
+# --- no model at all ---
+assert_provider "no HERMES_DEFAULT_MODEL → auto" "auto" ''
+
+echo
+echo "== results: $PASS passed, $FAIL failed =="
+[ "$FAIL" -eq 0 ]


### PR DESCRIPTION
## Root cause of #1926 / 2026-04-23 E2E A2A failure

Staging E2E step 8 A2A has been failing every run with:

\`\`\`
A2A returned an error-shaped response: Error code: 401 - {'error': {'message': 'Missing Authentication header', 'code': 401}}
\`\`\`

Issue #1926 guessed the 401 came from the platform auth layer (missing X-Workspace-ID). It didn't — the A2A returned 200 with a JSON-RPC result; the 401 above is **OpenRouter's error format** embedded in the agent's reply.

### Why hermes hit OpenRouter with bad auth

The E2E provides \`OPENAI_API_KEY\` as a workspace secret and sets model \`openai/gpt-4o\`. But SaaS staging also has \`OPENROUTER_API_KEY\` as a global secret. Old \`derive-provider.sh\` logic for \`openai/*\`:

\`\`\`sh
if [ -n "\${OPENROUTER_API_KEY:-}" ]; then
  PROVIDER="openrouter"            # ← wins even though operator provided OPENAI_API_KEY
elif [ -n "\${OPENAI_API_KEY:-}" ]; then
  PROVIDER="custom"
fi
\`\`\`

So hermes routed via OpenRouter with a global key that's stale or locked to a different tenant — OR rejected with \`401 Missing Authentication header\`, and that string surfaced verbatim in the agent response.

## Fix

Flip the priority: when the model is \`openai/*\` and \`OPENAI_API_KEY\` is present, always use \`custom\` (install.sh's direct-OpenAI bridge — already set up to wire \`HERMES_CUSTOM_BASE_URL=api.openai.com\` + \`HERMES_CUSTOM_API_KEY=\$OPENAI_API_KEY\` + \`api_mode=chat_completions\`). Fall through to \`openrouter\` only when no OpenAI key exists.

Operators who *want* OpenRouter for \`openai/*\` models can still:
- set \`HERMES_INFERENCE_PROVIDER=openrouter\` explicitly (respected at the top of derive-provider.sh), or
- use an \`openrouter/*\` model slug.

## Regression test

Adds \`scripts/test-derive-provider.sh\` — 12 offline shell assertions, runs in <1s with no hermes install or network:

\`\`\`
== results: 12 passed, 0 failed ==
\`\`\`

Includes the exact E2E failure scenario:
\`\`\`
PASS  openai/* + OPENAI_API_KEY + OPENROUTER_API_KEY → custom (#19 regression)
\`\`\`

## Verification plan
- [x] Unit tests: \`scripts/test-derive-provider.sh\` — 12/12 pass
- [ ] Next staging E2E (automatically runs on PR rebase) — step 8 A2A returns real PONG instead of OR 401

## Related
- monorepo#1926 — misdiagnosed as platform 401; actual root cause here
- monorepo#1902 — regression guards added; this PR completes the root-cause fix