### PR TITLE
ci: accept repository_dispatch from monorepo runtime publish

### DIFF
--- a/.github/workflows/publish-image.yml
+++ b/.github/workflows/publish-image.yml
@@ -6,6 +6,12 @@ name: publish-image
 # change it there if the publish pattern needs to evolve.
 
 on:
+  # Re-publish when a new molecule-ai-workspace-runtime is released to
+  # PyPI. Sent by molecule-core's publish-runtime.yml `cascade` job via
+  # repository_dispatch with event-type "runtime-published".
+  # client_payload.runtime_version carries the new version string.
+  repository_dispatch:
+    types: [runtime-published]
   push:
     branches: [main]
   workflow_dispatch:


### PR DESCRIPTION
Adds `repository_dispatch` trigger (event-type: `runtime-published`) to `publish-image.yml` so molecule-core's `publish-runtime.yml` cascade can rebuild this template image after a new `molecule-ai-workspace-runtime` PyPI release.

Part of the full runtime CD chain — see [molecule-core docs](https://github.com/Molecule-AI/molecule-core/blob/main/docs/workspace-runtime-package.md).

🤖 Generated with [Claude Code](https://claude.com/claude-code)