### PR TITLE
config: declare provision_timeout_seconds=720 (closes #2054 phase 3)

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -182,6 +182,16 @@ runtime_config:
   # 0 = no timeout; hermes-agent sessions can run long when tool-using.
   timeout: 0
 
+  # Cold-boot expectation surfaced to the canvas ProvisioningTimeout
+  # banner (Molecule-AI/molecule-core#2054). Hermes installs ripgrep +
+  # ffmpeg + node22 + builds hermes-agent from source + pulls Playwright
+  # + Chromium (~300MB), so cold boots routinely land at 8-13 min on
+  # staging EC2. 720s aligns with the SaaS E2E PROVISION_TIMEOUT_SECS=900
+  # so the UI warning surfaces shortly before the backend itself gives
+  # up. Without this declaration, canvas falls back to its 2-min default
+  # and false-alarms on every fresh hermes provision.
+  provision_timeout_seconds: 720
+
 # Tools hermes-agent ships natively. See `hermes tools` inside the
 # container for the interactive toggle — by default all 17 built-in
 # tool families are available (terminal, file read/write/edit,


### PR DESCRIPTION
[Molecule-Platform-Evolvement-Manager]

Closes Phase 3 of [Molecule-AI/molecule-core#2054](https://github.com/Molecule-AI/molecule-core/issues/2054).

## Chain status

- ✅ **Phase 1** ([core#2092 MERGED](https://github.com/Molecule-AI/molecule-core/pull/2092)): canvas plumbing — \`WorkspaceData.provision_timeout_ms\` → \`WorkspaceNodeData\` → \`ProvisioningTimeout\` resolver respects per-node override
- ✅ **Phase 2** ([core#2094 MERGED](https://github.com/Molecule-AI/molecule-core/pull/2094)): workspace-server reads \`runtime_config.provision_timeout_seconds\` from template manifests + surfaces in workspace List/Get response
- 🟡 **Phase 3 (this PR)**: declare the value HERE so the canvas banner threshold for hermes flows from this template manifest

## Why 720s

Hermes installs ripgrep + ffmpeg + node22 + builds hermes-agent from source + pulls Playwright + Chromium (~300MB). Staging EC2 cold boots routinely land at **8-13 min**.

720s (12 min) aligns with the SaaS E2E \`PROVISION_TIMEOUT_SECS=900\` so the UI warning surfaces shortly before the backend itself gives up. Without this declaration, canvas falls back to its 2-min default and false-alarms on every fresh hermes provision.

## Follow-up

A separate canvas PR will remove \`RUNTIME_PROFILES.hermes\` from \`canvas/src/lib/runtimeProfiles.ts\` now that the value flows server-side. Filing immediately.

## Test plan
- [ ] CI green
- [ ] After merge: workspace-server picks up the new value on next restart
- [ ] After staging deploy: a new hermes workspace's \`/workspaces/:id\` response includes \`provision_timeout_ms: 720000\`
- [ ] Canvas ProvisioningTimeout uses 720s threshold via \`node.data.provisionTimeoutMs\` path (not \`RUNTIME_PROFILES.hermes\`)