### PR TITLE
fix(start.sh): pick default model based on which API key is in env

### DIFF
--- a/start.sh
+++ b/start.sh
@@ -94,7 +94,51 @@ chmod 600 "$ENV_FILE"
 # the selection; operators override via HERMES_INFERENCE_PROVIDER
 # + HERMES_DEFAULT_MODEL env, or by editing config.yaml at runtime
 # inside the container.
-DEFAULT_MODEL="${HERMES_DEFAULT_MODEL:-nousresearch/hermes-4-70b}"
+# Pick a default model. The fallback used to be `nousresearch/hermes-4-70b`
+# unconditionally, which derives PROVIDER=openrouter when no Nous key is
+# present — and if OPENROUTER_API_KEY isn't set either, hermes-agent boots
+# with a config that points at a provider with no usable key, then 500s
+# at request time with "No LLM provider configured". Surfaces as a real
+# user-facing error whenever a workspace is provisioned with a single
+# provider key (e.g. just MINIMAX_API_KEY) but no explicit model
+# selection — the canvas's "set key, save, send" flow.
+#
+# Fix: when HERMES_DEFAULT_MODEL is unset and HERMES_INFERENCE_PROVIDER
+# is unset, pick the default model based on which API key is actually
+# present in env. Keeps the behaviour-when-everything-is-set unchanged
+# (operator-supplied HERMES_DEFAULT_MODEL still wins). Order below is
+# rough preference (direct providers preferred over OR routing for the
+# same model family).
+if [ -z "${HERMES_DEFAULT_MODEL:-}" ] && [ -z "${HERMES_INFERENCE_PROVIDER:-}" ]; then
+  if   [ -n "${HERMES_API_KEY:-}" ] || [ -n "${NOUS_API_KEY:-}" ]; then
+    HERMES_DEFAULT_MODEL="nousresearch/hermes-4-70b"
+  elif [ -n "${ANTHROPIC_API_KEY:-}" ]; then
+    HERMES_DEFAULT_MODEL="anthropic/claude-sonnet-4-5"
+  elif [ -n "${OPENAI_API_KEY:-}" ]; then
+    HERMES_DEFAULT_MODEL="openai/gpt-4o"
+  elif [ -n "${MINIMAX_API_KEY:-}" ]; then
+    HERMES_DEFAULT_MODEL="minimax/MiniMax-M2.7-highspeed"
+  elif [ -n "${MINIMAX_CN_API_KEY:-}" ]; then
+    HERMES_DEFAULT_MODEL="minimax-cn/abab6.5-chat"
+  elif [ -n "${GEMINI_API_KEY:-}" ] || [ -n "${GOOGLE_API_KEY:-}" ]; then
+    HERMES_DEFAULT_MODEL="gemini/gemini-2.0-flash"
+  elif [ -n "${DEEPSEEK_API_KEY:-}" ]; then
+    HERMES_DEFAULT_MODEL="deepseek/deepseek-chat"
+  elif [ -n "${KIMI_API_KEY:-}" ]; then
+    HERMES_DEFAULT_MODEL="kimi/kimi-k2"
+  elif [ -n "${OPENROUTER_API_KEY:-}" ]; then
+    HERMES_DEFAULT_MODEL="nousresearch/hermes-4-70b"  # routes via OR
+  else
+    # No provider key at all — keep the historical fallback so the
+    # error surfaces as the same "No LLM provider configured" message
+    # that operators are familiar with (rather than swapping it for a
+    # different obscure error).
+    HERMES_DEFAULT_MODEL="nousresearch/hermes-4-70b"
+  fi
+  echo "[start.sh] HERMES_DEFAULT_MODEL was unset; auto-selected '${HERMES_DEFAULT_MODEL}' from available API keys"
+fi
+
+DEFAULT_MODEL="${HERMES_DEFAULT_MODEL}"
 # Derive provider from model slug prefix — shared with install.sh via
 # scripts/derive-provider.sh so Docker + bare-host paths match.
 # Dockerfile COPYs scripts/ to /app/scripts; fall back to /scripts


### PR DESCRIPTION
## Repro

Provision a hermes workspace, set `MINIMAX_API_KEY` (or any single provider key), don't explicitly select a model via `HERMES_DEFAULT_MODEL`. `start.sh`'s fallback is unconditionally `nousresearch/hermes-4-70b`. `scripts/derive-provider.sh` maps that to `PROVIDER=openrouter` when no NOUS key is present. config.yaml is written with `provider: \"openrouter\"`. But `OPENROUTER_API_KEY` is also unset. hermes-agent boots, then errors at first request with:

> ```
> [hermes-agent error 500] {\"error\":{\"message\":\"Internal server error: No LLM provider configured. Run hermes model to select a provider, or run hermes setup for first-time configuration.\", ...}}
> ```

The error message points at first-time-setup, but the real cause is a config that names a provider whose key isn't present. Surfaced during RFC #2251 V1.0 gate #1 measurement (molecule-core#2256) — also hits any single-key tenant flow, including the canvas's \"paste a MiniMax key, save, send\" path.

## Fix

When neither \`HERMES_DEFAULT_MODEL\` nor \`HERMES_INFERENCE_PROVIDER\` is set, inspect which provider keys ARE present in env and pick a default model from a provider whose key is available. Operator-supplied \`HERMES_DEFAULT_MODEL\` still wins — no behavioural change on the explicit-selection path.

Order of preference (direct providers > OR routing for the same family):

| API key in env | Default model |
|---|---|
| \`HERMES_API_KEY\` / \`NOUS_API_KEY\` | \`nousresearch/hermes-4-70b\` (direct) |
| \`ANTHROPIC_API_KEY\` | \`anthropic/claude-sonnet-4-5\` |
| \`OPENAI_API_KEY\` | \`openai/gpt-4o\` (custom-provider bridge) |
| \`MINIMAX_API_KEY\` | \`minimax/MiniMax-M2.7-highspeed\` |
| \`MINIMAX_CN_API_KEY\` | \`minimax-cn/abab6.5-chat\` |
| \`GEMINI_API_KEY\` / \`GOOGLE_API_KEY\` | \`gemini/gemini-2.0-flash\` |
| \`DEEPSEEK_API_KEY\` | \`deepseek/deepseek-chat\` |
| \`KIMI_API_KEY\` | \`kimi/kimi-k2\` |
| \`OPENROUTER_API_KEY\` | \`nousresearch/hermes-4-70b\` (via OR) |
| (none) | \`nousresearch/hermes-4-70b\` (legacy fallback) |

When no key is present at all, the historical default remains so the existing \"No LLM provider configured\" error message still surfaces — useful for configuration-debugging callers, doesn't swap their familiar error for a different obscure one.

## Test plan

- [x] \`bash -n\` syntax check passes
- [x] Each auto-selected model derives the expected provider via \`scripts/derive-provider.sh\`:
  - \`MINIMAX_API_KEY\` → \`provider=minimax\`
  - \`ANTHROPIC_API_KEY\` → \`provider=anthropic\`
  - \`OPENROUTER_API_KEY\` → \`provider=openrouter\`
  - \`MINIMAX_API_KEY\` + \`OPENROUTER_API_KEY\` → MINIMAX wins (direct > OR)
- [x] Operator override path: \`HERMES_DEFAULT_MODEL=minimax/foo\` + \`MINIMAX_API_KEY=x\` → respects override
- [ ] Smoke test on a fresh local hermes workspace (manual; requires container rebuild from this branch's image)

## Notes

This intentionally keeps the auto-select OFF the existing \`scripts/derive-provider.sh\` and limits the change to \`start.sh\`. The derive script's contract is \"slug → provider name\" and shouldn't be expanded with key-presence logic — that's an env-resolution concern, not a slug-mapping concern.