### PR TITLE
Skip gateway spawn under MOLECULE_SMOKE_MODE

### DIFF
--- a/adapter.py
+++ b/adapter.py
@@ -109,6 +109,14 @@ class HermesAgentAdapter(BaseAdapter):
         workspace is marked unhealthy rather than silently forwarding to
         a dead port.
         """
+        # Boot-smoke contract (molecule-core#2275): start.sh's smoke-mode
+        # branch exec's molecule-runtime without spawning the gateway,
+        # so :8642 isn't listening. Skip the health probe under smoke
+        # mode — the runtime's smoke short-circuit fires after
+        # create_executor() returns.
+        if os.environ.get("MOLECULE_SMOKE_MODE") == "1":
+            return
+
         try:
             import httpx  # noqa: F401
         except ImportError as exc:  # pragma: no cover

--- a/start.sh
+++ b/start.sh
@@ -10,6 +10,19 @@
 
 set -euo pipefail
 
+# Boot-smoke contract (molecule-core#2275): the publish-image gate
+# invokes the runtime with stub creds and no network so it can
+# exercise lazy imports inside executor.execute(). The hermes
+# gateway needs valid creds + a writable log file, neither of which
+# exist in the smoke env. Skip directly to molecule-runtime — the
+# runtime's smoke_mode short-circuit fires after create_executor()
+# returns and exits before any A2A traffic is attempted. Real
+# production boots are unaffected.
+if [ "${MOLECULE_SMOKE_MODE:-0}" = "1" ]; then
+  echo "[start.sh] MOLECULE_SMOKE_MODE=1 — skipping hermes gateway spawn"
+  exec molecule-runtime
+fi
+
 HERMES_HOME="/tmp/.hermes"
 ENV_FILE="${HERMES_HOME}/.env"
 HERMES_CONFIG="${HERMES_HOME}/config.yaml"


### PR DESCRIPTION
## Summary
- The `publish-image` boot-smoke step (added by [molecule-core#2275](https://github.com/Molecule-AI/molecule-core/issues/2275)) invokes the runtime with stub creds and no network so it can exercise lazy imports inside `executor.execute()`.
- `start.sh` spawns a real `hermes gateway` subprocess that needs valid creds and a writable `/tmp/hermes-gateway.log` — neither exists in the smoke env. The gateway exits during boot and start.sh fails at the `:8642/health` readiness check before `molecule-runtime` ever starts.
- This adds an early-exec under `MOLECULE_SMOKE_MODE=1` right after `set -euo pipefail` so the runtime reaches its smoke short-circuit. Real production boots are unaffected.

## Verification

The smoke gate sets `MOLECULE_SMOKE_MODE=1` along with `MOLECULE_SMOKE_TIMEOUT_SECS=10` and a few stub API keys. With this fix:
- `start.sh` immediately `exec molecule-runtime`s without writing any hermes config or spawning the gateway
- Runtime calls `adapter.setup()` → `adapter.create_executor()` → smoke short-circuit invokes `executor.execute()` against a stub `RequestContext` with a 10s timeout

## Test plan
- [ ] CI publish-image workflow passes the boot-smoke step
- [ ] Image still boots normally in real production (env without `MOLECULE_SMOKE_MODE`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)