### PR TITLE
fix(executor): derive peer_id + peer_name distinctly from chat_id

### DIFF
--- a/executor.py
+++ b/executor.py
@@ -215,6 +215,7 @@ class HermesAgentProxyExecutor(AgentExecutor):
     ) -> None:
         message_id = uuid.uuid4().hex
         chat_id = self._derive_chat_id(context)
+        peer_id, peer_name = self._derive_peer_identity(context, fallback=chat_id)
         callback_url = (
             f"http://{self._callback_host}:{self._callback_port}{_DEFAULT_CALLBACK_PATH}"
         )
@@ -225,8 +226,8 @@ class HermesAgentProxyExecutor(AgentExecutor):
 
         payload = {
             "chat_id": chat_id,
-            "peer_id": chat_id,
-            "peer_name": chat_id,
+            "peer_id": peer_id,
+            "peer_name": peer_name,
             "content": prompt,
             "message_id": message_id,
             "callback_url": callback_url,
@@ -307,6 +308,35 @@ class HermesAgentProxyExecutor(AgentExecutor):
         if not future.done():
             future.set_result(content)
         return web.json_response({"ok": True})
+
+    @staticmethod
+    def _derive_peer_identity(context: RequestContext, *, fallback: str) -> tuple[str, str]:
+        """Pull peer_id + peer_name from the inbound context if the
+        a2a-sdk surfaces them; fall back to the chat_id otherwise.
+
+        peer_id and peer_name are distinct from chat_id — chat_id is
+        the per-conversation key (stable across turns), peer_id is the
+        sending agent's identity (workspace UUID), peer_name is its
+        registered display name. Sending all three equal works for
+        single-tenant proxy use, but downstream plugin logs become
+        unreadable and any peer-routing logic in the plugin would
+        misroute. Look up the actual values when available.
+        """
+        peer_id = fallback
+        peer_name = fallback
+        message = getattr(context, "message", None)
+        if message is not None:
+            for attr in ("peer_id", "sender_id", "from_id"):
+                value = getattr(message, attr, None)
+                if value:
+                    peer_id = str(value)
+                    break
+            for attr in ("peer_name", "sender_name", "from_name"):
+                value = getattr(message, attr, None)
+                if value:
+                    peer_name = str(value)
+                    break
+        return peer_id, peer_name
 
     @staticmethod
     def _derive_chat_id(context: RequestContext) -> str:

--- a/tests/test_executor_plugin_path.py
+++ b/tests/test_executor_plugin_path.py
@@ -624,6 +624,53 @@ def test_derive_chat_id_uses_message_id_camelcase():
     assert HermesAgentProxyExecutor._derive_chat_id(ctx) == "msg-camelcase"
 
 
+# ---- peer identity derivation ---------------------------------------
+
+
+def test_derive_peer_identity_falls_back_to_chat_id_when_message_missing():
+    """Single-tenant proxy default: when no peer fields surface, both
+    peer_id and peer_name match the chat_id we already derived."""
+    ctx = MagicMock()
+    ctx.message = None
+    pid, pname = HermesAgentProxyExecutor._derive_peer_identity(
+        ctx, fallback="task-A"
+    )
+    assert pid == "task-A"
+    assert pname == "task-A"
+
+
+def test_derive_peer_identity_picks_up_explicit_peer_fields():
+    """When the a2a-sdk surfaces peer_id / peer_name on the message,
+    use them instead of the chat_id fallback so plugin logs and any
+    future peer-routing logic stay accurate."""
+    ctx = MagicMock()
+    msg = MagicMock(spec=["peer_id", "peer_name"])
+    msg.peer_id = "ws-uuid-7777"
+    msg.peer_name = "researcher-bot"
+    ctx.message = msg
+    pid, pname = HermesAgentProxyExecutor._derive_peer_identity(
+        ctx, fallback="task-A"
+    )
+    assert pid == "ws-uuid-7777"
+    assert pname == "researcher-bot"
+
+
+def test_derive_peer_identity_accepts_legacy_sender_attrs():
+    """If a future a2a-sdk renames peer_id → sender_id, the helper
+    still picks it up. Keeps us forward-compatible with the schema
+    drift the codex template has already documented."""
+    ctx = MagicMock()
+    msg = MagicMock(spec=["sender_id", "from_name"])
+    msg.sender_id = "ws-legacy"
+    msg.from_name = "legacy-bot"
+    ctx.message = msg
+    pid, pname = HermesAgentProxyExecutor._derive_peer_identity(
+        ctx, fallback="fallback"
+    )
+    assert pid == "ws-legacy"
+    assert pname == "legacy-bot"
+
+
 @pytest.mark.asyncio
 async def test_cancel_returns_none():
     """cancel() is a noop today — confirm it doesn't raise and returns


### PR DESCRIPTION
## Summary

Self-review followup to PR #32 (see issue #33).

The plugin `/a2a/inbound` payload set `chat_id`, `peer_id`, and `peer_name` all to the same derived `task_id`. Wire-accepted but semantically wrong:
- `chat_id` — per-conversation key (stable across turns) ✅
- `peer_id` — sender workspace UUID
- `peer_name` — sender's registered display name

Adds `_derive_peer_identity(context, *, fallback)` that picks up real values from `context.message` (`peer_id` / `peer_name`, plus legacy `sender_id` / `from_name`) when the a2a-sdk surfaces them. Falls back to `chat_id` otherwise — current behavior preserved when no peer fields are present.

## Test plan

- [x] 3 new unit tests cover: missing message → fallback; explicit peer fields → used; legacy attrs (sender_id / from_name) → used.
- [x] Full suite: **39 tests pass** (was 36).
- [x] No prod-payload shape change for single-tenant proxy use; only enriches when a2a-sdk has the data.

🤖 Generated with [Claude Code](https://claude.com/claude-code)