### PR TITLE
Align env vars with hermes-agent upstream + add 12 missing providers

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -150,8 +150,13 @@ chmod 600 "$HERMES_HOME/.env"
 # direct openai provider), nousresearch/* → nous-or-openrouter based
 # on keys present, etc.). Explicit HERMES_INFERENCE_PROVIDER in the
 # env always wins.
-DEFAULT_MODEL="${HERMES_DEFAULT_MODEL:-nousresearch/hermes-4-70b}"
-HERMES_DEFAULT_MODEL="${DEFAULT_MODEL}" \
+# Read BOTH HERMES_INFERENCE_MODEL (upstream's actual env var, see
+# NousResearch/hermes-agent website/docs/reference/environment-variables.md)
+# AND HERMES_DEFAULT_MODEL (legacy name we invented before 2026-05).
+# Workspace-server still writes the legacy name during the migration
+# window — accepting both keeps existing provisions green.
+DEFAULT_MODEL="${HERMES_INFERENCE_MODEL:-${HERMES_DEFAULT_MODEL:-nousresearch/hermes-4-70b}}"
+HERMES_INFERENCE_MODEL="${DEFAULT_MODEL}" \
   . "$(dirname "$0")/scripts/derive-provider.sh"
 
 # --- OpenAI bridge: PROVIDER=custom + chat_completions api_mode ---

--- a/scripts/derive-provider.sh
+++ b/scripts/derive-provider.sh
@@ -5,9 +5,18 @@
 #
 # Contract:
 #   Reads:  $HERMES_INFERENCE_PROVIDER (if already set, we respect it)
-#           $HERMES_DEFAULT_MODEL      (slug, e.g. "minimax/MiniMax-M2.7-highspeed")
+#           $HERMES_INFERENCE_MODEL    (preferred — matches upstream env name)
+#           $HERMES_DEFAULT_MODEL      (legacy fallback — name we invented before
+#                                       2026-05; workspace-server still writes
+#                                       it during the migration window)
 #           $HERMES_API_KEY / $NOUS_API_KEY (affect the nousresearch/* branch)
 #   Writes: $PROVIDER — the derived provider name, or "auto" if unknown.
+#
+# Upstream's actual env var is $HERMES_INFERENCE_MODEL (see
+# website/docs/reference/environment-variables.md in NousResearch/hermes-agent).
+# We accept both for one release cycle so workspaces booting under the legacy
+# control-plane don't break — drop $HERMES_DEFAULT_MODEL once workspace-server
+# is updated to write the upstream name.
 #
 # Why the per-template sub-script (vs doing this in CP): every runtime
 # has its own provider taxonomy. Keeping the logic inside the template
@@ -31,12 +40,15 @@ if [ -n "${HERMES_INFERENCE_PROVIDER:-}" ]; then
   return 0 2>/dev/null || exit 0
 fi
 
-if [ -z "${HERMES_DEFAULT_MODEL:-}" ]; then
+# Resolve the model slug — prefer the upstream env name, fall back to legacy.
+_HERMES_MODEL="${HERMES_INFERENCE_MODEL:-${HERMES_DEFAULT_MODEL:-}}"
+
+if [ -z "${_HERMES_MODEL}" ]; then
   PROVIDER="auto"
   return 0 2>/dev/null || exit 0
 fi
 
-case "${HERMES_DEFAULT_MODEL}" in
+case "${_HERMES_MODEL}" in
   # Keep full CN-suffix as provider so chinese-region keys route right
   minimax-cn/*)            PROVIDER="minimax-cn" ;;
   kimi-coding-cn/*)        PROVIDER="kimi-coding-cn" ;;
@@ -91,6 +103,23 @@ case "${HERMES_DEFAULT_MODEL}" in
   # Explicit catch-alls
   openrouter/*)            PROVIDER="openrouter" ;;
   custom/*)                PROVIDER="custom" ;;
+
+  # Additional 1:1 prefix→provider mappings — kept aligned with upstream's
+  # HERMES_INFERENCE_PROVIDER list (website/docs/reference/environment-variables.md
+  # in NousResearch/hermes-agent, v0.12.0 / 2026-04-30). Place these BEFORE the
+  # catch-all so they win.
+  xai/*|grok/*)            PROVIDER="xai" ;;
+  bedrock/*|aws/*)         PROVIDER="bedrock" ;;
+  tencent/*|tencent-tokenhub/*) PROVIDER="tencent-tokenhub" ;;
+  gmi/*)                   PROVIDER="gmi" ;;
+  qwen-oauth/*)            PROVIDER="qwen-oauth" ;;
+  lmstudio/*|lm-studio/*)  PROVIDER="lmstudio" ;;
+  minimax-oauth/*)         PROVIDER="minimax-oauth" ;;
+  alibaba-coding-plan/*)   PROVIDER="alibaba-coding-plan" ;;
+  google-gemini-cli/*)     PROVIDER="google-gemini-cli" ;;
+  openai-codex/*)          PROVIDER="openai-codex" ;;
+  copilot-acp/*)           PROVIDER="copilot-acp" ;;
+  copilot/*)               PROVIDER="copilot" ;;
 
   # Unknown prefix → let hermes auto-detect
   *)                       PROVIDER="auto" ;;

--- a/start.sh
+++ b/start.sh
@@ -46,7 +46,9 @@ ${HERMES_INFERENCE_PROVIDER:+HERMES_INFERENCE_PROVIDER=${HERMES_INFERENCE_PROVID
 # Auxiliary model defaults — used by vision, web summarization, MoA.
 ${HERMES_AUXILIARY_PROVIDER:+HERMES_AUXILIARY_PROVIDER=${HERMES_AUXILIARY_PROVIDER}}
 # ── Primary inference providers (keyed) ───────────────────────
-${HERMES_API_KEY:+HERMES_API_KEY=${HERMES_API_KEY}}
+# NOTE: HERMES_API_KEY intentionally NOT forwarded — upstream uses it only for
+# the TUI gateway bridge, not as an LLM credential. Provider keys go below
+# (NOUS_API_KEY, OPENROUTER_API_KEY, OPENAI_API_KEY, …).
 ${NOUS_API_KEY:+NOUS_API_KEY=${NOUS_API_KEY}}
 ${OPENROUTER_API_KEY:+OPENROUTER_API_KEY=${OPENROUTER_API_KEY}}
 ${OPENAI_API_KEY:+OPENAI_API_KEY=${OPENAI_API_KEY}}
@@ -92,16 +94,22 @@ chmod 600 "$ENV_FILE"
 # (defaulting to anthropic/claude-opus-4.6 + provider:auto) which
 # doesn't match the workspace's intended model. Our template owns
 # the selection; operators override via HERMES_INFERENCE_PROVIDER
-# + HERMES_DEFAULT_MODEL env, or by editing config.yaml at runtime
+# + HERMES_INFERENCE_MODEL env, or by editing config.yaml at runtime
 # inside the container.
-DEFAULT_MODEL="${HERMES_DEFAULT_MODEL:-nousresearch/hermes-4-70b}"
+#
+# Read BOTH HERMES_INFERENCE_MODEL (upstream's actual env var, see
+# NousResearch/hermes-agent website/docs/reference/environment-variables.md)
+# AND HERMES_DEFAULT_MODEL (legacy name we invented before 2026-05).
+# Workspace-server still writes the legacy name during the migration
+# window — accepting both keeps boots green until that's fixed.
+DEFAULT_MODEL="${HERMES_INFERENCE_MODEL:-${HERMES_DEFAULT_MODEL:-nousresearch/hermes-4-70b}}"
 # Derive provider from model slug prefix — shared with install.sh via
 # scripts/derive-provider.sh so Docker + bare-host paths match.
 # Dockerfile COPYs scripts/ to /app/scripts; fall back to /scripts
 # for dev environments that run start.sh with a different WORKDIR.
 DERIVE_SCRIPT="/app/scripts/derive-provider.sh"
 [ -f "$DERIVE_SCRIPT" ] || DERIVE_SCRIPT="/scripts/derive-provider.sh"
-HERMES_DEFAULT_MODEL="${DEFAULT_MODEL}" . "$DERIVE_SCRIPT"
+HERMES_INFERENCE_MODEL="${DEFAULT_MODEL}" . "$DERIVE_SCRIPT"
 
 # --- OpenAI bridge: custom provider + chat_completions api_mode ---
 # Symmetric with install.sh. See install.sh for the full explanation.

--- a/tests/test_derive_provider.sh
+++ b/tests/test_derive_provider.sh
@@ -1,0 +1,154 @@
+#!/usr/bin/env bash
+# tests/test_derive_provider.sh — sh-style assertion tests for
+# scripts/derive-provider.sh. Sourced under bash so PROVIDER is captured
+# in the test process.
+#
+# Run with:   bash tests/test_derive_provider.sh
+# Exit code:  0 on success, 1 on any failure.
+#
+# We deliberately avoid bats / external test frameworks — this template
+# repo has no Python/bats test deps installed in CI today; staying in
+# pure bash means the script runs anywhere `bash` is on PATH.
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+DERIVE="${SCRIPT_DIR}/scripts/derive-provider.sh"
+
+if [ ! -f "${DERIVE}" ]; then
+  echo "FAIL: cannot find derive-provider.sh at ${DERIVE}" >&2
+  exit 1
+fi
+
+PASS=0
+FAIL=0
+FAILURES=()
+
+# derive  <name> <expected_provider>  [VAR=value ...]
+# Spawns a clean subshell, sets the supplied env vars, sources the
+# script, and asserts $PROVIDER matches.
+derive() {
+  local name="$1"
+  local expected="$2"
+  shift 2
+  local actual
+  actual="$(env -i PATH="$PATH" HOME="$HOME" "$@" bash -c "
+    set -uo pipefail
+    unset HERMES_INFERENCE_PROVIDER HERMES_INFERENCE_MODEL HERMES_DEFAULT_MODEL
+    unset HERMES_API_KEY NOUS_API_KEY OPENROUTER_API_KEY OPENAI_API_KEY
+    # Re-export anything the caller passed (env -i wiped them).
+    for kv in \"\$@\"; do
+      export \"\$kv\"
+    done
+    PROVIDER=
+    . '${DERIVE}'
+    printf '%s' \"\$PROVIDER\"
+  " _ "$@" 2>&1)"
+  if [ "${actual}" = "${expected}" ]; then
+    PASS=$((PASS + 1))
+    printf "  PASS  %-60s -> %s\n" "${name}" "${actual}"
+  else
+    FAIL=$((FAIL + 1))
+    FAILURES+=("${name}: expected '${expected}', got '${actual}'")
+    printf "  FAIL  %-60s expected '%s' got '%s'\n" "${name}" "${expected}" "${actual}"
+  fi
+}
+
+echo "== derive-provider.sh tests =="
+
+# --- Fix B: env-var rename + legacy fallback -------------------------------
+derive "anthropic via HERMES_INFERENCE_MODEL (preferred name)" \
+  "anthropic" "HERMES_INFERENCE_MODEL=anthropic/claude-sonnet-4-5"
+
+derive "anthropic via HERMES_DEFAULT_MODEL (legacy fallback)" \
+  "anthropic" "HERMES_DEFAULT_MODEL=anthropic/claude-sonnet-4-5"
+
+derive "empty model resolves to auto" \
+  "auto" "HERMES_INFERENCE_MODEL="
+
+derive "no env vars at all resolves to auto" \
+  "auto"
+
+derive "HERMES_INFERENCE_MODEL preferred over HERMES_DEFAULT_MODEL when both set" \
+  "anthropic" \
+  "HERMES_INFERENCE_MODEL=anthropic/claude-sonnet-4-5" \
+  "HERMES_DEFAULT_MODEL=deepseek/deepseek-v3"
+
+derive "explicit HERMES_INFERENCE_PROVIDER wins over both model vars" \
+  "openrouter" \
+  "HERMES_INFERENCE_PROVIDER=openrouter" \
+  "HERMES_INFERENCE_MODEL=anthropic/claude-sonnet-4-5"
+
+# --- Fix D: 12 newly-added providers --------------------------------------
+derive "xai/grok-4 -> xai" \
+  "xai" "HERMES_INFERENCE_MODEL=xai/grok-4"
+
+derive "grok/grok-2 -> xai (alias)" \
+  "xai" "HERMES_INFERENCE_MODEL=grok/grok-2"
+
+derive "bedrock/anthropic.claude-sonnet-4 -> bedrock" \
+  "bedrock" "HERMES_INFERENCE_MODEL=bedrock/anthropic.claude-sonnet-4"
+
+derive "aws/anthropic.claude -> bedrock (alias)" \
+  "bedrock" "HERMES_INFERENCE_MODEL=aws/anthropic.claude-sonnet-4"
+
+derive "tencent/hunyuan -> tencent-tokenhub" \
+  "tencent-tokenhub" "HERMES_INFERENCE_MODEL=tencent/hunyuan-pro"
+
+derive "tencent-tokenhub/hunyuan -> tencent-tokenhub" \
+  "tencent-tokenhub" "HERMES_INFERENCE_MODEL=tencent-tokenhub/hunyuan-pro"
+
+derive "gmi/foo -> gmi" \
+  "gmi" "HERMES_INFERENCE_MODEL=gmi/some-model"
+
+derive "qwen-oauth/qwen-max -> qwen-oauth" \
+  "qwen-oauth" "HERMES_INFERENCE_MODEL=qwen-oauth/qwen-max"
+
+derive "lmstudio/local-llama -> lmstudio" \
+  "lmstudio" "HERMES_INFERENCE_MODEL=lmstudio/local-llama"
+
+derive "lm-studio/local-llama -> lmstudio (alias)" \
+  "lmstudio" "HERMES_INFERENCE_MODEL=lm-studio/local-llama"
+
+derive "minimax-oauth/m2 -> minimax-oauth" \
+  "minimax-oauth" "HERMES_INFERENCE_MODEL=minimax-oauth/MiniMax-M2"
+
+derive "alibaba-coding-plan/qwen -> alibaba-coding-plan" \
+  "alibaba-coding-plan" "HERMES_INFERENCE_MODEL=alibaba-coding-plan/qwen3-coder"
+
+derive "google-gemini-cli/gemini-2.0 -> google-gemini-cli" \
+  "google-gemini-cli" "HERMES_INFERENCE_MODEL=google-gemini-cli/gemini-2.0-flash"
+
+derive "openai-codex/codex-mini -> openai-codex" \
+  "openai-codex" "HERMES_INFERENCE_MODEL=openai-codex/codex-mini-latest"
+
+derive "copilot/gpt-4o -> copilot" \
+  "copilot" "HERMES_INFERENCE_MODEL=copilot/gpt-4o"
+
+derive "copilot-acp/claude-sonnet -> copilot-acp" \
+  "copilot-acp" "HERMES_INFERENCE_MODEL=copilot-acp/claude-sonnet-4"
+
+# --- Regression: existing prefixes still work after Fix D additions -------
+derive "minimax/* still routes to minimax (not minimax-oauth)" \
+  "minimax" "HERMES_INFERENCE_MODEL=minimax/MiniMax-M2.7"
+
+derive "alibaba/* still routes to alibaba (not alibaba-coding-plan)" \
+  "alibaba" "HERMES_INFERENCE_MODEL=alibaba/qwen3-32b"
+
+derive "qwen/* still routes to alibaba (not qwen-oauth)" \
+  "alibaba" "HERMES_INFERENCE_MODEL=qwen/qwen3-32b"
+
+derive "unknown prefix falls through to auto" \
+  "auto" "HERMES_INFERENCE_MODEL=some-unknown-vendor/foo-bar"
+
+echo
+echo "== summary: ${PASS} passed, ${FAIL} failed =="
+if [ "${FAIL}" -gt 0 ]; then
+  echo
+  echo "failures:"
+  for f in "${FAILURES[@]}"; do
+    echo "  - ${f}"
+  done
+  exit 1
+fi
+exit 0


### PR DESCRIPTION
## Summary

Three small but real cleanups to align `template-hermes` with `hermes-agent` v0.12.0 (`NousResearch/hermes-agent`, 2026-04-30):

1. **Env var rename, backwards-compatible.** Upstream's actual env var is `HERMES_INFERENCE_MODEL`; we'd been calling it `HERMES_DEFAULT_MODEL` (a name we invented). `start.sh` / `install.sh` / `scripts/derive-provider.sh` now read **both** for one release cycle and prefer the upstream name when present.
2. **Drop `HERMES_API_KEY` no-op injection from `start.sh`'s `.env` heredoc.** That env var only feeds hermes-agent's TUI gateway bridge — it is **not** an LLM provider credential. Provider keys go through `OPENROUTER_API_KEY` / `OPENAI_API_KEY` / `NOUS_API_KEY` / etc. (`install.sh` left untouched in this PR — intentional, see "out of scope" below.)
3. **Add 12 missing providers to `derive-provider.sh`** so `xai/`, `bedrock/`, `lmstudio/`, `copilot/`, etc., route to the correct provider instead of `auto`.

## Upstream provider list

Verified against `website/docs/reference/environment-variables.md` for `HERMES_INFERENCE_PROVIDER` in `NousResearch/hermes-agent` v0.12.0:

> `auto`, `custom`, `openrouter`, `nous`, `openai-codex`, `copilot`, `copilot-acp`, `anthropic`, `huggingface`, `gemini`, `zai`, `kimi-coding`, `kimi-coding-cn`, `minimax`, `minimax-cn`, `minimax-oauth`, `kilocode`, `xiaomi`, `arcee`, `gmi`, `alibaba`, `alibaba-coding-plan`, `deepseek`, `nvidia`, `ollama-cloud`, `xai`, `google-gemini-cli`, `qwen-oauth`, `bedrock`, `opencode-zen`, `opencode-go`, `ai-gateway`, `tencent-tokenhub`

Newly-added prefixes (12): `xai/grok`, `bedrock/aws`, `tencent/tencent-tokenhub`, `gmi`, `qwen-oauth`, `lmstudio/lm-studio`, `minimax-oauth`, `alibaba-coding-plan`, `google-gemini-cli`, `openai-codex`, `copilot`, `copilot-acp`.

## Backwards-compat shim

`HERMES_DEFAULT_MODEL` continues to work for one release cycle:

```bash
# In all three of start.sh, install.sh, scripts/derive-provider.sh:
DEFAULT_MODEL="${HERMES_INFERENCE_MODEL:-${HERMES_DEFAULT_MODEL:-nousresearch/hermes-4-70b}}"
```

This is **non-negotiable** because `molecule-controlplane`'s workspace-server still writes the legacy name when injecting per-tenant provisioning env. Removing the legacy fallback before workspace-server is updated would silently regress every workspace boot to `nousresearch/hermes-4-70b` (the hard-coded fallback).

## Out of scope (follow-up PRs)

- **workspace-server should be updated to write `HERMES_INFERENCE_MODEL`** (instead of `HERMES_DEFAULT_MODEL`). After that ships and propagates, the legacy fallback in this PR can be dropped.
- `install.sh`'s `HERMES_API_KEY=…` line in the `.env` heredoc is preserved in this PR — `derive-provider.sh`'s `nousresearch/*` branch still treats `HERMES_API_KEY` as a Nous Portal credential signal. Cleaning that up coherently across both files needs a separate look at how SaaS provisioner maps secrets.

## Test plan

- [x] `bash -n` clean on `start.sh`, `install.sh`, `scripts/derive-provider.sh`, `tests/test_derive_provider.sh`
- [x] `python3 .molecule-ci/scripts/validate-workspace-template.py` passes
- [x] `bash tests/test_derive_provider.sh` — **26/26 PASS** covering: legacy fallback, `INFERENCE_MODEL` precedence over `DEFAULT_MODEL`, all 12 new providers, regression cases for adjacent prefixes (`minimax` vs `minimax-oauth`, `qwen` vs `qwen-oauth`, `alibaba` vs `alibaba-coding-plan`)
- [ ] CI green
- [ ] Manual: boot a workspace that still receives `HERMES_DEFAULT_MODEL=anthropic/claude-sonnet-4-5` from the legacy CP — confirm `~/.hermes/config.yaml` still gets `model.default: anthropic/claude-sonnet-4-5` and `model.provider: anthropic`