### PR TITLE
feat: per-vendor env audit + routing parity with claude-code (task #249)

### DIFF
--- a/adapter.py
+++ b/adapter.py
@@ -15,9 +15,82 @@ docs/PLANNING.md for the rewrite rationale.
 """
 from __future__ import annotations
 
+import logging
 import os
 
 from molecule_runtime.adapters.base import BaseAdapter, AdapterConfig, RuntimeCapabilities
+
+logger = logging.getLogger(__name__)
+
+
+# Auth env names to audit at boot. Order is informational; presence/absence
+# of each is logged so the operator can see at a glance which key the
+# workspace was started with vs which is missing. NEVER log values — just
+# the boolean "set"/"unset" per name.
+#
+# Hermes-agent consumes every per-vendor key DIRECTLY (no projection onto
+# ANTHROPIC_AUTH_TOKEN like claude-code requires), so the audit list
+# enumerates the same per-vendor names that start.sh forwards into
+# hermes-agent's .env. The contrast with claude-code's audit (which
+# includes ANTHROPIC_AUTH_TOKEN + ANTHROPIC_BASE_URL because that SDK is
+# Anthropic-only) is deliberate — see task #249 reconciliation note.
+#
+# Adding a new vendor: add its env name here AND to start.sh's audit
+# for-loop (the cross-file test in tests/test_adapter_logging.py pins
+# the two lists set-equal).
+_AUTH_ENV_AUDIT = (
+    # Nous Portal + the OpenRouter catch-all (covers any model that
+    # routes through hermes's openrouter provider, including the openai/*
+    # slug fallback).
+    "HERMES_API_KEY",
+    "NOUS_API_KEY",
+    "OPENROUTER_API_KEY",
+    # Direct-SDK providers hermes calls natively.
+    "OPENAI_API_KEY",
+    "ANTHROPIC_API_KEY",
+    "GEMINI_API_KEY",
+    "GOOGLE_API_KEY",
+    "DEEPSEEK_API_KEY",
+    "GLM_API_KEY",
+    "KIMI_API_KEY",
+    "KIMI_CN_API_KEY",
+    "MINIMAX_API_KEY",
+    "MINIMAX_CN_API_KEY",
+    "DASHSCOPE_API_KEY",
+    "XIAOMI_API_KEY",
+    "ARCEEAI_API_KEY",
+    "NVIDIA_API_KEY",
+    "OLLAMA_API_KEY",
+    "HF_TOKEN",
+    "AI_GATEWAY_API_KEY",
+    "KILOCODE_API_KEY",
+    "OPENCODE_ZEN_API_KEY",
+    "OPENCODE_GO_API_KEY",
+    "COPILOT_GITHUB_TOKEN",
+    "GH_TOKEN",
+)
+
+
+def _audit_auth_env_presence() -> None:
+    """Log a one-line snapshot of which auth env names are set.
+
+    Logs NAMES + presence ("set"/"unset"), never VALUES. Lets an
+    operator reading docker logs answer "is this a missing key
+    problem or a wrong-model problem?" in one glance — paired with
+    start.sh's pre-Python audit (which fires before the gateway
+    spawns), the operator sees the same set of names twice and can
+    correlate "key was present at start.sh, gone by adapter.setup()"
+    if it ever happens.
+
+    Mirrors claude-code's _audit_auth_env_presence (template-claude-code
+    PR #32) but with hermes's per-vendor audit list — hermes has no
+    ANTHROPIC_AUTH_TOKEN/ANTHROPIC_BASE_URL projection layer.
+    """
+    snapshot = ", ".join(
+        f"{name}={'set' if os.environ.get(name) else 'unset'}"
+        for name in _AUTH_ENV_AUDIT
+    )
+    logger.info("auth env audit: %s", snapshot)
 
 
 class HermesAgentAdapter(BaseAdapter):
@@ -117,6 +190,17 @@ class HermesAgentAdapter(BaseAdapter):
         # short-circuit fires after create_executor() returns.
         if os.environ.get("MOLECULE_SMOKE_MODE") == "1":
             return
+
+        # Audit which auth-relevant env vars are present (NAMES ONLY —
+        # never values). Boot-time visibility into "is the key missing
+        # or wrong" is the diagnosis question that bit the 2026-05-02
+        # crash-loop incident in claude-code; ship the same surgical
+        # fix here proactively so a hermes operator with multiple
+        # vendor keys can tell "is MINIMAX_API_KEY visible to my
+        # workspace?" from `docker logs` alone. start.sh logs the same
+        # set as a shell loop pre-gosu; this entry confirms it survived
+        # the privilege drop and got handed to the Python adapter.
+        _audit_auth_env_presence()
 
         try:
             import httpx  # noqa: F401

--- a/start.sh
+++ b/start.sh
@@ -23,6 +23,28 @@ if [ "${MOLECULE_SMOKE_MODE:-0}" = "1" ]; then
   exec molecule-runtime
 fi
 
+# Boot-context auth env audit — emitted on EVERY non-smoke boot, including
+# every restart of a crash-loop. Lets `docker logs` answer "what auth env
+# was actually present?" without having to docker exec into a dying
+# container. Logs NAMES of auth-relevant env vars, never VALUES.
+#
+# Mirrors adapter.py's _AUTH_ENV_AUDIT — keep the two lists in sync
+# (tests/test_adapter_logging.py asserts set-equality so they can't drift).
+# The shell loop fires BEFORE the gateway spawns; the Python adapter logs
+# the same set in its setup() AFTER molecule-runtime boots. An operator
+# diagnosing a wedge can correlate "key present at start.sh, gone in
+# adapter" if the privilege drop ever loses one.
+echo "----- start.sh auth env audit $(date -u +%Y-%m-%dT%H:%M:%SZ) -----"
+for var in HERMES_API_KEY NOUS_API_KEY OPENROUTER_API_KEY OPENAI_API_KEY ANTHROPIC_API_KEY GEMINI_API_KEY GOOGLE_API_KEY DEEPSEEK_API_KEY GLM_API_KEY KIMI_API_KEY KIMI_CN_API_KEY MINIMAX_API_KEY MINIMAX_CN_API_KEY DASHSCOPE_API_KEY XIAOMI_API_KEY ARCEEAI_API_KEY NVIDIA_API_KEY OLLAMA_API_KEY HF_TOKEN AI_GATEWAY_API_KEY KILOCODE_API_KEY OPENCODE_ZEN_API_KEY OPENCODE_GO_API_KEY COPILOT_GITHUB_TOKEN GH_TOKEN; do
+  eval "val=\${$var:-}"
+  if [ -n "$val" ]; then
+    echo "[start.sh] env $var=set"
+  else
+    echo "[start.sh] env $var=unset"
+  fi
+done
+echo "------------------------------------------------"
+
 HERMES_HOME="/tmp/.hermes"
 ENV_FILE="${HERMES_HOME}/.env"
 HERMES_CONFIG="${HERMES_HOME}/config.yaml"

--- a/tests/test_adapter_logging.py
+++ b/tests/test_adapter_logging.py
@@ -1,0 +1,197 @@
+"""Tests for the adapter-side boot debug logging helpers.
+
+The 2026-05-02 crash-loop diagnosis (in template-claude-code) hinged on
+operators being able to see, from `docker logs` alone, *which* auth env
+names were set vs unset at boot. This test pins the same contract for the
+hermes template — `_audit_auth_env_presence` must emit a single INFO line
+listing every name in `_AUTH_ENV_AUDIT` with its presence status, and
+must NEVER include the value.
+
+Hermes diverges from claude-code in WHICH names are in the audit set:
+hermes-agent reads each per-vendor env directly (no projection onto
+ANTHROPIC_AUTH_TOKEN), so the audit list enumerates the full per-vendor
+set that start.sh forwards into hermes-agent's .env.
+
+Test isolation: adapter.py imports molecule_runtime + a2a-style deps at
+module load. Neither is installed in this template's lean test env (the
+template ships its own stripped-down test set so CI doesn't pull a heavy
+runtime wheel just to lint the adapter helpers). We stub them with empty
+modules so the audit helpers can import cleanly.
+"""
+from __future__ import annotations
+
+import importlib.util
+import logging
+import re
+import sys
+import types
+from pathlib import Path
+
+import pytest
+
+
+@pytest.fixture
+def adapter_module(monkeypatch):
+    """Load the template's adapter module without its molecule_runtime dep.
+
+    The full adapter requires molecule_runtime at import time, which
+    isn't installed in the lean test env. We stub it with an empty
+    module exposing the three names adapter.py imports
+    (BaseAdapter, AdapterConfig, RuntimeCapabilities) so the
+    module-level helpers (_AUTH_ENV_AUDIT, _audit_auth_env_presence)
+    can be imported in isolation.
+    """
+    pkg = types.ModuleType("molecule_runtime")
+    sub = types.ModuleType("molecule_runtime.adapters")
+    base = types.ModuleType("molecule_runtime.adapters.base")
+    base.BaseAdapter = type("BaseAdapter", (), {})
+    base.AdapterConfig = type("AdapterConfig", (), {})
+    base.RuntimeCapabilities = type("RuntimeCapabilities", (), {})
+    monkeypatch.setitem(sys.modules, "molecule_runtime", pkg)
+    monkeypatch.setitem(sys.modules, "molecule_runtime.adapters", sub)
+    monkeypatch.setitem(sys.modules, "molecule_runtime.adapters.base", base)
+
+    template_dir = Path(__file__).resolve().parent.parent
+    monkeypatch.syspath_prepend(str(template_dir))
+
+    # Force-reload so the stubs take effect even if a sibling test
+    # already imported the real (or partially-stubbed) module first.
+    sys.modules.pop("adapter", None)
+    spec = importlib.util.spec_from_file_location(
+        "adapter", template_dir / "adapter.py"
+    )
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def test_audit_lists_every_name_with_presence(adapter_module, monkeypatch, caplog):
+    """The audit log must enumerate every name in _AUTH_ENV_AUDIT, set or unset."""
+    # Set ONE vendor key with a sentinel value; clear everything else.
+    monkeypatch.setenv("MINIMAX_API_KEY", "fake-secret-MUST-NOT-LEAK")
+    for name in adapter_module._AUTH_ENV_AUDIT:
+        if name != "MINIMAX_API_KEY":
+            monkeypatch.delenv(name, raising=False)
+
+    with caplog.at_level(logging.INFO, logger="adapter"):
+        adapter_module._audit_auth_env_presence()
+
+    # Single log record, INFO level, prefix "auth env audit:"
+    matching = [r for r in caplog.records if "auth env audit" in r.getMessage()]
+    assert len(matching) == 1, (
+        f"expected exactly one audit record, got {len(matching)}"
+    )
+    msg = matching[0].getMessage()
+
+    # Every audited name appears with set/unset status
+    for name in adapter_module._AUTH_ENV_AUDIT:
+        assert f"{name}=" in msg, f"audit message missing {name}: {msg!r}"
+
+    # MINIMAX_API_KEY is set, the others unset
+    assert "MINIMAX_API_KEY=set" in msg
+    assert "ANTHROPIC_API_KEY=unset" in msg
+    assert "GLM_API_KEY=unset" in msg
+    assert "DEEPSEEK_API_KEY=unset" in msg
+
+    # Critical security assertion: the SECRET VALUE itself must NOT
+    # appear. If this regresses, the audit is leaking secrets to
+    # operator-visible docker logs and (worse) to the platform's
+    # central log aggregator.
+    assert "fake-secret-MUST-NOT-LEAK" not in msg, (
+        "audit log leaked the env VALUE — must be names + set/unset only"
+    )
+
+
+def test_audit_with_all_unset(adapter_module, monkeypatch, caplog):
+    """All names report 'unset' when no auth env is configured.
+
+    This is the crash-loop scenario — workspace boots with no provider
+    key at all. The audit must still fire (an all-unset line is the
+    operator's fastest signal that the env injection failed entirely
+    upstream, not just that one specific key was missed).
+    """
+    for name in adapter_module._AUTH_ENV_AUDIT:
+        monkeypatch.delenv(name, raising=False)
+
+    with caplog.at_level(logging.INFO, logger="adapter"):
+        adapter_module._audit_auth_env_presence()
+
+    matching = [r for r in caplog.records if "auth env audit" in r.getMessage()]
+    assert len(matching) == 1
+    msg = matching[0].getMessage()
+    for name in adapter_module._AUTH_ENV_AUDIT:
+        assert f"{name}=unset" in msg
+
+
+def test_audit_treats_empty_string_as_unset(adapter_module, monkeypatch, caplog):
+    """Empty-string env values report as 'unset' — matches start.sh semantics.
+
+    workspace-server's nil/empty handling could plausibly export
+    MINIMAX_API_KEY="" instead of omitting it. The shell side already
+    treats `${VAR:+...}` as unset for empty strings (which is why
+    start.sh's .env-write block doesn't forward empty keys), so the
+    Python audit must agree: an empty key is, semantically, unset.
+    Otherwise the operator sees `MINIMAX_API_KEY=set` in the audit
+    while hermes-agent silently rejects it as missing.
+    """
+    monkeypatch.setenv("MINIMAX_API_KEY", "")
+    for name in adapter_module._AUTH_ENV_AUDIT:
+        if name != "MINIMAX_API_KEY":
+            monkeypatch.delenv(name, raising=False)
+
+    with caplog.at_level(logging.INFO, logger="adapter"):
+        adapter_module._audit_auth_env_presence()
+
+    msg = [
+        r.getMessage()
+        for r in caplog.records
+        if "auth env audit" in r.getMessage()
+    ][0]
+    assert "MINIMAX_API_KEY=unset" in msg
+
+
+def test_audit_env_list_matches_start_sh(adapter_module):
+    """_AUTH_ENV_AUDIT in adapter.py must mirror the for-loop in start.sh.
+
+    start.sh emits the same set of NAME=set/unset lines BEFORE the
+    hermes gateway spawns and BEFORE the Python adapter ever runs, so
+    an operator can correlate a missing key across the gateway boot.
+    If the two lists drift, an env name added in one place but not
+    the other becomes invisible at one tier — exactly the
+    crash-loop diagnosis gap that bit claude-code 2026-05-02.
+
+    Pin the union by parsing the shell loop and asserting set-equality.
+    Selector: the audit for-loop is the unique start.sh for-loop that
+    iterates over `var` AND mentions HERMES_API_KEY (other for-loops
+    in start.sh iterate over `_` for readiness polling and don't
+    contain provider env names).
+    """
+    template_dir = Path(__file__).resolve().parent.parent
+    start_sh = (template_dir / "start.sh").read_text()
+
+    loop_line = next(
+        (
+            line for line in start_sh.splitlines()
+            if "for var in" in line and "HERMES_API_KEY" in line
+        ),
+        None,
+    )
+    assert loop_line, "start.sh missing the auth-env audit for-loop"
+
+    # `for var in A B C; do` → ['A', 'B', 'C']
+    names_in_shell = (
+        loop_line.split("for var in", 1)[1]
+        .split(";", 1)[0]
+        .split()
+    )
+
+    # Filter to identifier-shaped tokens to be robust against future
+    # additions of inline shell expansion.
+    names_in_shell = [n for n in names_in_shell if re.fullmatch(r"[A-Z_][A-Z0-9_]*", n)]
+
+    assert set(names_in_shell) == set(adapter_module._AUTH_ENV_AUDIT), (
+        f"adapter.py _AUTH_ENV_AUDIT ({set(adapter_module._AUTH_ENV_AUDIT)}) "
+        f"and start.sh for-loop ({set(names_in_shell)}) disagree on the "
+        "audit set — keep them in sync (see the comment in adapter.py "
+        "above _AUTH_ENV_AUDIT)."
+    )


### PR DESCRIPTION
## Summary

Ports the diagnostic half of the per-vendor env pattern that shipped to `template-claude-code` in PR #32 (and the molecule-monorepo task tracker as #248) to this repo. The "routing" half deliberately doesn't apply here — see the reconciliation note below.

Three surgical edits:

1. **`adapter.py`** — adds `_AUTH_ENV_AUDIT` (tuple of 25 vendor env names) and `_audit_auth_env_presence()`. Wired into `setup()` after the smoke-mode short-circuit so non-smoke boots emit one INFO line: `auth env audit: HERMES_API_KEY=unset, NOUS_API_KEY=unset, ..., MINIMAX_API_KEY=set, ...`. Names + presence only — never values.

2. **`start.sh`** — pre-gateway audit loop emits the same set of names as `[start.sh] env NAME=set/unset` lines, fired BEFORE `hermes gateway` spawns. Lets `docker logs` answer "did the env even reach the workspace" without `docker exec` into a dying container.

3. **`tests/test_adapter_logging.py`** — 4 new tests, one of which is a cross-file sync gate that parses `start.sh`'s for-loop and asserts set-equality with `adapter.py`'s `_AUTH_ENV_AUDIT`. The sentinel test pins that an env value never appears in the audit output (the secrets-leak guard from the claude-code version).

## Reconciliation note (task #249)

The original task description was framed against the claude-code pattern, which has TWO layers: (a) per-vendor env names + (b) projection onto `ANTHROPIC_AUTH_TOKEN` / `ANTHROPIC_BASE_URL` (because the claude-code SDK only consumes `ANTHROPIC_*`). Hermes is different:

- **Per-vendor env names already exposed** by `start.sh` (lines 65-89, post-task-#241) and `config.yaml` (lines 80-166) — `MINIMAX_API_KEY`, `GLM_API_KEY`, `KIMI_API_KEY`, `DEEPSEEK_API_KEY`, plus 20+ more all forwarded into hermes-agent's `.env` and surfaced as model-level `required_env` in the canvas dropdown.
- **Routing layer not needed**: hermes-agent natively reads each per-vendor env directly via its own provider router (see `scripts/derive-provider.sh` for the model-slug → provider mapping that's the source of truth, pinned by task #242). There's no `ANTHROPIC_*` envelope to project onto. Forcing one would *introduce* the same multi-vendor collision claude-code's per-vendor work was designed to fix.
- **Audit-log tier was the genuine gap**. That's all this PR ships.

| Tier | claude-code state | hermes state | this PR |
|---|---|---|---|
| Per-vendor env exposed | shipped | shipped (task #241) | unchanged |
| Vendor key listed in `config.yaml`'s `required_env` | shipped | shipped (task #241) | unchanged |
| ANTHROPIC_* projection layer | shipped (PR #2538) | N/A — hermes consumes natively | not applicable |
| Boot audit log (adapter side) | shipped (PR #32) | missing | **added** |
| Boot audit log (entrypoint/start.sh side) | shipped (PR #32) | missing | **added** |
| Cross-file sync test | shipped (PR #32) | missing | **added** |

## Validation

- `pytest tests/test_adapter_logging.py --no-cov -v` → 4/4 pass
- `bash -n start.sh` + `python3 -c "import ast; ast.parse(open(...).read())"` on both files → clean
- Smoke-tested the audit loop directly with `MINIMAX_API_KEY="should-not-leak"` + `GLM_API_KEY=""` — output reports `MINIMAX_API_KEY=set` and `GLM_API_KEY=unset`, no value leak.

## Test plan

- [x] All 4 new tests green locally
- [x] Cross-file sync gate in place (audit list can't drift between `adapter.py` and `start.sh` without test failure)
- [x] Sentinel value test confirms audit log never leaks env values
- [ ] CI must verify

Closes molecule-monorepo task #249. Sibling of `template-claude-code` PR #32.

🤖 Generated with [Claude Code](https://claude.com/claude-code)