### PR TITLE
fix(hermes): default to minimax/MiniMax-M2.1 when MINIMAX_API_KEY is the only LLM key

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -150,6 +150,28 @@ chmod 600 "$HERMES_HOME/.env"
 # direct openai provider), nousresearch/* → nous-or-openrouter based
 # on keys present, etc.). Explicit HERMES_INFERENCE_PROVIDER in the
 # env always wins.
+# Auto-flip the default model to a MiniMax slug when the operator's
+# only present LLM key is MINIMAX_API_KEY. Without this, the
+# nousresearch/hermes-4-70b default routes to OpenRouter (no
+# OPENROUTER_API_KEY = 401) and the gateway crashes with "No LLM
+# provider configured" on first chat request, which propagates as
+# `[hermes-agent error 500]` on the platform A2A. Caught live during
+# the 4-runtime A2A E2E (2026-05-03). The minimax/* prefix routes
+# directly to hermes's native `minimax` provider via derive-provider.sh.
+# Test against BOTH HERMES_INFERENCE_MODEL (upstream env var) and the
+# legacy HERMES_DEFAULT_MODEL so the auto-flip fires only when neither
+# is set explicitly.
+if [ -z "${HERMES_INFERENCE_MODEL:-}" ] \
+  && [ -z "${HERMES_DEFAULT_MODEL:-}" ] \
+  && [ -n "${MINIMAX_API_KEY:-}" ] \
+  && [ -z "${OPENROUTER_API_KEY:-}" ] \
+  && [ -z "${OPENAI_API_KEY:-}" ] \
+  && [ -z "${HERMES_API_KEY:-}" ] \
+  && [ -z "${NOUS_API_KEY:-}" ] \
+  && [ -z "${ANTHROPIC_API_KEY:-}" ]; then
+  HERMES_INFERENCE_MODEL="minimax/MiniMax-M2.1"
+  echo "[install.sh] no provider key but MINIMAX_API_KEY set → defaulting to ${HERMES_INFERENCE_MODEL}"
+fi
 # Read BOTH HERMES_INFERENCE_MODEL (upstream's actual env var, see
 # NousResearch/hermes-agent website/docs/reference/environment-variables.md)
 # AND HERMES_DEFAULT_MODEL (legacy name we invented before 2026-05).


### PR DESCRIPTION
## Summary

When `install.sh` runs with `MINIMAX_API_KEY` as the only present LLM key (no `OPENROUTER`/`OPENAI`/`NOUS`/`HERMES`/`ANTHROPIC` keys), promote `HERMES_DEFAULT_MODEL` to `minimax/MiniMax-M2.1` before sourcing `derive-provider.sh`.

## Why

Default `nousresearch/hermes-4-70b` → `derive-provider.sh` → `openrouter` provider → no `OPENROUTER_API_KEY` → gateway crashes on first chat completions:

```
RuntimeError: No LLM provider configured. Run `hermes model` to select a provider, or run `hermes setup` for first-time configuration.
```

The adapter's `setup()` then fails:

```
RuntimeError: hermes-agent surface not reachable at http://127.0.0.1:8642/health
```

`/registry/register` never fires, workspace flips to `status=failed` inside the 12-min provisioning timeout.

`minimax/MiniMax-M2.1` routes via `derive-provider.sh`'s `minimax/*` branch to hermes's native `minimax` provider, which reads `MINIMAX_API_KEY` directly.

Same root cause as molecule-ai-workspace-template-codex#14 + molecule-ai-workspace-template-openclaw#19: the 3 templates all hit the missing-MODEL_PROVIDER pass-through gap from different angles.

## Test plan

- [x] `bash -n install.sh` passes
- [x] Verified live: `hermes -z 'reply with pong'` returns `pong` against the same `MINIMAX_API_KEY` + `minimax/MiniMax-M2.1` config this PR generates.
- [ ] Re-provision after merge to confirm zero manual config needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)