### PR TITLE
feat(hermes): wire molecule a2a_mcp_server into hermes MCP loader (#41)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,3 +25,4 @@ jobs:
       - run: bash scripts/test-derive-provider.sh
       - run: bash scripts/test-install-prefix-strip.sh
       - run: bash scripts/test-load-workspace-config.sh
+      - run: bash scripts/test-install-mcp-wireup.sh

--- a/install.sh
+++ b/install.sh
@@ -230,6 +230,32 @@ if [[ "${HERMES_CUSTOM_BASE_URL:-}" =~ ^https?://api\.openai\.com(/|$) ]]; then
   fi
 fi
 
+# --- Resolve python interpreter that has molecule_runtime ---
+# molecule-ai-workspace-runtime is pip-installed on the host BEFORE this
+# script runs (see install.sh header). The hermes MCP loader spawns the
+# server as a subprocess via `command + args`, so we need an absolute
+# path to a python that can `import molecule_runtime`. Detect at install
+# time so the recorded config.yaml entry survives PATH changes between
+# now and when hermes gateway forks the subprocess.
+#
+# Falls back gracefully when molecule_runtime isn't importable (the
+# template's CI smoke build installs only requirements.txt, not the
+# runtime wheel) — emit a warning, skip the mcp_servers block, and let
+# install.sh continue. The agent boots without A2A MCP tools but the
+# gateway is still healthy.
+MOLECULE_MCP_PYTHON=""
+for candidate in python3 python; do
+  resolved="$(command -v "$candidate" 2>/dev/null || true)"
+  if [ -n "$resolved" ] && "$resolved" -c "import molecule_runtime" >/dev/null 2>&1; then
+    MOLECULE_MCP_PYTHON="$resolved"
+    break
+  fi
+done
+if [ -z "$MOLECULE_MCP_PYTHON" ]; then
+  echo "[install.sh] WARNING: molecule_runtime not importable from any python on PATH;" \
+    "skipping a2a MCP wire-up — hermes agent will boot without list_peers / delegate_task"
+fi
+
 {
   echo "# Seeded by template-hermes install.sh on $(date -u -Iseconds)"
   echo "# Rewritten each boot from HERMES_DEFAULT_MODEL + HERMES_INFERENCE_PROVIDER env."
@@ -248,6 +274,42 @@ fi
   # Emit the field only when explicitly set — absent = hermes auto-detect.
   if [ -n "${HERMES_CUSTOM_API_MODE:-}" ]; then
     echo "  api_mode: \"${HERMES_CUSTOM_API_MODE}\""
+  fi
+  # --- Molecule a2a_mcp_server wire-up (issue #41) ---
+  # Hermes-agent's MCP loader (~/.hermes/hermes-agent/hermes_cli/mcp_config.py)
+  # reads `mcp_servers:` from config.yaml and forks each entry as a stdio
+  # subprocess. We register the platform A2A MCP server (list_peers,
+  # delegate_task, delegate_task_async, check_task_status, get_workspace_info,
+  # commit_memory, recall_memory, send_message_to_user) so the hermes
+  # agent has tool parity with the claude-code template's
+  # claude_sdk_executor.mcp_servers["a2a"] entry.
+  #
+  # The server reads WORKSPACE_ID + PLATFORM_URL + MOLECULE_ORG_ID +
+  # CONFIGS_DIR from env at startup (see molecule_runtime/a2a_client.py
+  # and platform_auth.py). hermes's _build_safe_env (tools/mcp_tool.py)
+  # only forwards a tiny baseline (PATH/HOME/USER/...), so we MUST
+  # explicitly enumerate every var the server needs in the `env:` block
+  # of the entry — variable interpolation against the OUTER process
+  # environment happens at hermes-fork time.
+  #
+  # Idempotency: install.sh unconditionally rewrites this whole config
+  # file each run, so re-running the script overwrites (never duplicates)
+  # the mcp_servers block.
+  if [ -n "${MOLECULE_MCP_PYTHON}" ]; then
+    echo "mcp_servers:"
+    echo "  molecule:"
+    echo "    enabled: true"
+    echo "    command: \"${MOLECULE_MCP_PYTHON}\""
+    echo "    args: [\"-m\", \"molecule_runtime.a2a_mcp_server\"]"
+    echo "    env:"
+    echo "      WORKSPACE_ID: \"${WORKSPACE_ID:-}\""
+    echo "      PLATFORM_URL: \"${PLATFORM_URL:-http://platform:8080}\""
+    if [ -n "${MOLECULE_ORG_ID:-}" ]; then
+      echo "      MOLECULE_ORG_ID: \"${MOLECULE_ORG_ID}\""
+    fi
+    if [ -n "${CONFIGS_DIR:-}" ]; then
+      echo "      CONFIGS_DIR: \"${CONFIGS_DIR}\""
+    fi
   fi
 } >"$HERMES_HOME/config.yaml"
 

--- a/scripts/test-install-mcp-wireup.sh
+++ b/scripts/test-install-mcp-wireup.sh
@@ -1,0 +1,198 @@
+#!/usr/bin/env bash
+# test-install-mcp-wireup.sh — regression tests for the molecule a2a_mcp_server
+# wire-up in install.sh (issue #41).
+#
+# install.sh writes ~/.hermes/config.yaml on every run; the molecule MCP
+# entry must land under `mcp_servers.molecule:` with the right command,
+# args, and env block so hermes-agent's MCP loader (mcp_config.py +
+# mcp_tool.py) can fork the a2a_mcp_server stdio subprocess.
+#
+# Design mirrors test-install-prefix-strip.sh: rather than partial-source
+# install.sh (which would attempt apt-get + curl downloads), we inline
+# the exact emit logic and parity-grep install.sh for the load-bearing
+# substrings so drift fails the test instead of shipping silently.
+
+set -u
+HERE="$(cd "$(dirname "$0")" && pwd)"
+INSTALL="$HERE/../install.sh"
+
+PASS=0
+FAIL=0
+
+# The logic under test — mirrored from install.sh. Keep in sync with the
+# emit block; the parity check below greps install.sh for anchor strings
+# so any drift fails loudly.
+emit_mcp_block() {
+  if [ -n "${MOLECULE_MCP_PYTHON:-}" ]; then
+    echo "mcp_servers:"
+    echo "  molecule:"
+    echo "    enabled: true"
+    echo "    command: \"${MOLECULE_MCP_PYTHON}\""
+    echo "    args: [\"-m\", \"molecule_runtime.a2a_mcp_server\"]"
+    echo "    env:"
+    echo "      WORKSPACE_ID: \"${WORKSPACE_ID:-}\""
+    echo "      PLATFORM_URL: \"${PLATFORM_URL:-http://platform:8080}\""
+    if [ -n "${MOLECULE_ORG_ID:-}" ]; then
+      echo "      MOLECULE_ORG_ID: \"${MOLECULE_ORG_ID}\""
+    fi
+    if [ -n "${CONFIGS_DIR:-}" ]; then
+      echo "      CONFIGS_DIR: \"${CONFIGS_DIR}\""
+    fi
+  fi
+}
+
+run_case() {
+  local label="$1"
+  shift
+  bash -c "
+    set -u
+    $(declare -f emit_mcp_block)
+    MOLECULE_MCP_PYTHON=''
+    WORKSPACE_ID=''
+    PLATFORM_URL=''
+    MOLECULE_ORG_ID=''
+    CONFIGS_DIR=''
+    $*
+    emit_mcp_block
+  " 2>/dev/null
+}
+
+assert_contains() {
+  local label="$1" needle="$2" haystack="$3"
+  if printf '%s' "$haystack" | grep -F -q -- "$needle"; then
+    echo "  PASS  $label"
+    PASS=$((PASS+1))
+  else
+    echo "  FAIL  $label  →  missing substring: $needle"
+    echo "        actual output:"
+    printf '%s\n' "$haystack" | sed 's/^/          /'
+    FAIL=$((FAIL+1))
+  fi
+}
+
+assert_not_contains() {
+  local label="$1" needle="$2" haystack="$3"
+  if ! printf '%s' "$haystack" | grep -F -q -- "$needle"; then
+    echo "  PASS  $label"
+    PASS=$((PASS+1))
+  else
+    echo "  FAIL  $label  →  unexpected substring present: $needle"
+    FAIL=$((FAIL+1))
+  fi
+}
+
+assert_empty() {
+  local label="$1" actual="$2"
+  if [ -z "$actual" ]; then
+    echo "  PASS  $label"
+    PASS=$((PASS+1))
+  else
+    echo "  FAIL  $label  →  expected empty, got:"
+    printf '%s\n' "$actual" | sed 's/^/          /'
+    FAIL=$((FAIL+1))
+  fi
+}
+
+echo "== install.sh mcp wire-up =="
+
+# --- Case A: full env (production EC2 shape) ---
+out=$(run_case "full env" '
+  MOLECULE_MCP_PYTHON=/usr/bin/python3
+  WORKSPACE_ID=ws-abc-123
+  PLATFORM_URL=https://platform.staging.moleculesai.app
+  MOLECULE_ORG_ID=org-uuid-xyz
+  CONFIGS_DIR=/configs
+')
+assert_contains "A.1: emits mcp_servers header" "mcp_servers:" "$out"
+assert_contains "A.2: emits molecule entry"     "  molecule:"   "$out"
+assert_contains "A.3: enabled: true"            "    enabled: true" "$out"
+assert_contains "A.4: command points at resolved python" "    command: \"/usr/bin/python3\"" "$out"
+assert_contains "A.5: args invokes a2a_mcp_server module" \
+  "    args: [\"-m\", \"molecule_runtime.a2a_mcp_server\"]" "$out"
+assert_contains "A.6: WORKSPACE_ID forwarded"   "      WORKSPACE_ID: \"ws-abc-123\"" "$out"
+assert_contains "A.7: PLATFORM_URL forwarded"   "      PLATFORM_URL: \"https://platform.staging.moleculesai.app\"" "$out"
+assert_contains "A.8: MOLECULE_ORG_ID forwarded" "      MOLECULE_ORG_ID: \"org-uuid-xyz\"" "$out"
+assert_contains "A.9: CONFIGS_DIR forwarded"    "      CONFIGS_DIR: \"/configs\"" "$out"
+
+# --- Case B: minimum required env (WORKSPACE_ID + PLATFORM_URL only) ---
+out=$(run_case "minimal env" '
+  MOLECULE_MCP_PYTHON=/usr/local/bin/python3
+  WORKSPACE_ID=ws-min
+  PLATFORM_URL=http://platform:8080
+')
+assert_contains "B.1: still emits mcp_servers when ORG_ID/CONFIGS_DIR unset" \
+  "mcp_servers:" "$out"
+assert_contains "B.2: WORKSPACE_ID present" "WORKSPACE_ID: \"ws-min\"" "$out"
+assert_not_contains "B.3: optional MOLECULE_ORG_ID NOT emitted when unset" \
+  "MOLECULE_ORG_ID:" "$out"
+assert_not_contains "B.4: optional CONFIGS_DIR NOT emitted when unset" \
+  "CONFIGS_DIR:" "$out"
+
+# --- Case C: PLATFORM_URL falls back to platform:8080 (matches a2a_client.py) ---
+out=$(run_case "PLATFORM_URL fallback" '
+  MOLECULE_MCP_PYTHON=/usr/bin/python3
+  WORKSPACE_ID=ws-fallback
+')
+assert_contains "C.1: PLATFORM_URL defaults to http://platform:8080" \
+  "      PLATFORM_URL: \"http://platform:8080\"" "$out"
+
+# --- Case D: no python found → block is skipped entirely ---
+out=$(run_case "no python found" '
+  MOLECULE_MCP_PYTHON=
+  WORKSPACE_ID=ws-nopy
+  PLATFORM_URL=http://platform:8080
+')
+assert_empty "D.1: empty MOLECULE_MCP_PYTHON skips entire mcp_servers block" "$out"
+
+# --- Case E: WORKSPACE_ID may be empty (boot-smoke / dev) → entry still valid YAML ---
+out=$(run_case "empty WORKSPACE_ID is valid YAML" '
+  MOLECULE_MCP_PYTHON=/usr/bin/python3
+  WORKSPACE_ID=
+  PLATFORM_URL=http://platform:8080
+')
+assert_contains "E.1: empty WORKSPACE_ID emits as empty string" \
+  "      WORKSPACE_ID: \"\"" "$out"
+
+# --- Parity check: install.sh must contain the same anchor strings ---
+echo
+echo "== parity with install.sh =="
+PARITY_FAIL=0
+for pattern in \
+  'MOLECULE_MCP_PYTHON' \
+  'import molecule_runtime' \
+  'mcp_servers:' \
+  '  molecule:' \
+  '    enabled: true' \
+  'molecule_runtime.a2a_mcp_server' \
+  'WORKSPACE_ID:' \
+  'PLATFORM_URL:' \
+  'MOLECULE_ORG_ID:' \
+  'CONFIGS_DIR:'; do
+  if ! grep -F -q -- "$pattern" "$INSTALL"; then
+    echo "  FAIL  install.sh missing substring: $pattern"
+    PARITY_FAIL=$((PARITY_FAIL+1))
+  fi
+done
+if [ "$PARITY_FAIL" -eq 0 ]; then
+  echo "  PASS  install.sh contains expected logic blocks"
+  PASS=$((PASS+1))
+else
+  FAIL=$((FAIL+PARITY_FAIL))
+fi
+
+# --- Idempotency: install.sh's config.yaml emit is a single-block rewrite ---
+# (the `{ ... } > "$HERMES_HOME/config.yaml"` pattern means re-running can't
+# accumulate duplicate mcp_servers entries by construction).
+echo
+echo "== idempotency =="
+if grep -F -q '} >"$HERMES_HOME/config.yaml"' "$INSTALL"; then
+  echo "  PASS  install.sh uses single-block redirect to config.yaml (overwrite-on-rerun)"
+  PASS=$((PASS+1))
+else
+  echo "  FAIL  install.sh no longer uses } >\"\$HERMES_HOME/config.yaml\" — re-runs may duplicate mcp_servers"
+  FAIL=$((FAIL+1))
+fi
+
+echo
+echo "== results: $PASS passed, $FAIL failed =="
+[ "$FAIL" -eq 0 ]


### PR DESCRIPTION
Closes #41.

## Summary

Hermes-agent's MCP loader (`~/.hermes/hermes-agent/hermes_cli/mcp_config.py`) reads `mcp_servers:` from `~/.hermes/config.yaml` and forks each entry as a stdio subprocess. This template's `install.sh` wrote `model:` + `provider:` to that file but never registered the platform A2A MCP server, so the hermes agent had no `list_peers` / `delegate_task` / `commit_memory` / `recall_memory` / `send_message_to_user` tooling.

Verified live in the canvas (2026-05-03): Hermes Agent told the operator *"I don't have a `list_peers` tool available in my current toolset"*, listing only its built-in browser/code/files/tasks/memory tools.

This PR wires the same `molecule_runtime/a2a_mcp_server.py` that `claude_sdk_executor.mcp_servers["a2a"]` uses on the claude-code path into the hermes config.yaml emit block, so the hermes agent gets full tool parity with claude-code agents on a fresh provision.

## What changed

**`install.sh`** — after the existing `model:` / `provider:` write, append an `mcp_servers.molecule:` entry. Resolves the python interpreter that has `molecule_runtime` importable at install time so the absolute path survives any PATH churn between install and hermes-fork. Forwards the four env vars the server actually reads (`WORKSPACE_ID`, `PLATFORM_URL`, `MOLECULE_ORG_ID`, `CONFIGS_DIR`) explicitly in the entry's `env:` block — hermes's `_build_safe_env` (`tools/mcp_tool.py`) only auto-passes a tiny baseline (`PATH`/`HOME`/`USER`/...).

**Idempotent by construction**: install.sh already does a single-block unconditional rewrite (`{ ... } > "$HERMES_HOME/config.yaml"`) of config.yaml each run, so re-runs overwrite (never duplicate) the `mcp_servers` entry.

**Graceful degradation**: if `molecule_runtime` isn't importable from any python on PATH (the template's CI smoke build installs only `requirements.txt`, not the runtime wheel), emit a warning and skip the `mcp_servers` block. The gateway still boots healthy; the agent just doesn't get A2A tools — same shape as before this change.

**`scripts/test-install-mcp-wireup.sh`** — 18 bash-assertion cases matching the existing `test-install-prefix-strip.sh` style:
- Full env (production EC2 shape) → all 4 env vars present, command + args correct
- Minimal env → optional `MOLECULE_ORG_ID` / `CONFIGS_DIR` not emitted
- `PLATFORM_URL` falls back to `http://platform:8080` (matches `a2a_client.py` default)
- Missing python → entire `mcp_servers` block skipped, no malformed YAML
- Empty `WORKSPACE_ID` → emits as empty string (boot-smoke / dev still produces valid YAML)
- 8-anchor parity grep against `install.sh` so any drift fails loudly
- Idempotency anchor: confirms install.sh still uses single-block redirect

**`.github/workflows/ci.yml`** — wire the new test into the existing `shell-tests` job alongside the other three bash test scripts.

## Test plan

- [x] `bash -n install.sh` → SYNTAX OK
- [x] `bash scripts/test-install-mcp-wireup.sh` → 18 passed, 0 failed
- [x] `bash scripts/test-install-prefix-strip.sh` → 10 passed, 0 failed (regression check)
- [x] `bash scripts/test-derive-provider.sh` → 12 passed, 0 failed (regression check)
- [x] `bash scripts/test-load-workspace-config.sh` → 11 passed, 0 failed (regression check)
- [x] `bash tests/test_derive_provider.sh` → 26 passed, 0 failed (regression check)
- [x] YAML emitted by the new block parses with `yaml.safe_load` and has the exact keys hermes-agent's `mcp_config.py` consumes (manual sanity check)
- [ ] CI green on this PR
- [ ] After merge: provision a fresh hermes workspace alongside another runtime, ask hermes "list your peer workspaces" in the canvas — expect it to call `list_peers` and return the list (was the live failure mode in #41)

## Companion gaps (out of scope here)

The same wire-up is missing on the other two non-claude-code runtimes:
- `molecule-ai-workspace-template-codex#15`
- `molecule-ai-workspace-template-openclaw#20`

Same mechanical fix once this lands; each template has its own MCP loader surface (codex has its own config, openclaw has its own).

🤖 Generated with [Claude Code](https://claude.com/claude-code)