### PR TITLE
fix(mcp): detect molecule_runtime in /opt/molecule-venv first

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -244,9 +244,19 @@ fi
 # install.sh continue. The agent boots without A2A MCP tools but the
 # gateway is still healthy.
 MOLECULE_MCP_PYTHON=""
-for candidate in python3 python; do
-  resolved="$(command -v "$candidate" 2>/dev/null || true)"
-  if [ -n "$resolved" ] && "$resolved" -c "import molecule_runtime" >/dev/null 2>&1; then
+# Try the runtime venv first — molecule-ai-workspace-runtime is
+# pip-installed there by the host install.sh, NOT into /usr/bin/python3.
+# Searching `command -v python3` first picks the system interpreter
+# which has only the stdlib and no molecule_runtime, so the wire-up
+# silently no-ops and the agent boots without list_peers (caught live
+# 2026-05-03 on hermes MCP-verify EC2 i-0a2e502add1ee646b).
+for candidate in /opt/molecule-venv/bin/python3 /opt/molecule-venv/bin/python python3 python; do
+  case "$candidate" in
+    /*) resolved="$candidate" ;;
+    *)  resolved="$(command -v "$candidate" 2>/dev/null || true)" ;;
+  esac
+  if [ -n "$resolved" ] && [ -x "$resolved" ] && \
+     "$resolved" -c "import molecule_runtime" >/dev/null 2>&1; then
     MOLECULE_MCP_PYTHON="$resolved"
     break
   fi


### PR DESCRIPTION
## Summary

The MCP wire-up loop searched \`python3\` and \`python\` on PATH, which resolves to \`/usr/bin/python3\` — system stdlib only, no \`molecule_runtime\`. Every hermes provision silently logged:

\`\`\`
[install.sh] WARNING: molecule_runtime not importable from any python on PATH;
skipping a2a MCP wire-up — hermes agent will boot without list_peers / delegate_task
\`\`\`

…and the agent boots blind to its peers.

## Repro

MCP-verify EC2 \`i-0a2e502add1ee646b\` (workspace \`9982283a-7abb-4be7-b959-563945b650af\`), 2026-05-03 — agent's first reply to \`hi can you see your peers?\` was *"Nope! I'm running in isolation"* because no MCP tools were loaded. \`hermes mcp list\` returned \`No MCP servers configured.\`

## Fix

\`molecule-ai-workspace-runtime\` is pip-installed by the host \`install.sh\` into \`/opt/molecule-venv\`, NOT into the system python. Add the venv path as the first candidate so the MCP block actually gets written to \`~/.hermes/config.yaml\`.

## Test plan

- [x] \`bash -n install.sh\` passes
- [ ] Workflow tests pass on CI
- [ ] Re-provision a hermes workspace post-merge and confirm \`hermes mcp list\` shows \`molecule\` and the agent calls \`list_peers\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)