### PR TITLE
test(mcp): cover venv-first python detection loop

### DIFF
--- a/scripts/test-install-mcp-wireup.sh
+++ b/scripts/test-install-mcp-wireup.sh
@@ -153,6 +153,121 @@ out=$(run_case "empty WORKSPACE_ID is valid YAML" '
 assert_contains "E.1: empty WORKSPACE_ID emits as empty string" \
   "      WORKSPACE_ID: \"\"" "$out"
 
+# --- Case F: detect_python loop picks the venv interpreter first ----
+# Mirror of the install.sh detection loop introduced in PR #43. The
+# loop walks /opt/molecule-venv/bin first so the system /usr/bin/python3
+# (stdlib only, no molecule_runtime) doesn't get picked, which used to
+# cause every hermes provision to silently log "skipping a2a MCP wire-up"
+# and boot the agent without list_peers/delegate_task.
+#
+# Mirroring (rather than sourcing install.sh) keeps the test isolated
+# from install.sh's apt-get/curl side effects. The parity-grep block
+# below ensures the mirrored candidate list stays in sync with install.sh
+# — drift fails loudly instead of shipping silently.
+detect_python() {
+  local result=""
+  local resolved=""
+  for candidate in "$@"; do
+    case "$candidate" in
+      /*) resolved="$candidate" ;;
+      *)  resolved="$(command -v "$candidate" 2>/dev/null || true)" ;;
+    esac
+    if [ -n "$resolved" ] && [ -x "$resolved" ] && \
+       "$resolved" -c "import molecule_runtime" >/dev/null 2>&1; then
+      result="$resolved"
+      break
+    fi
+  done
+  echo "$result"
+}
+
+echo
+echo "== detect_python loop (PR #43) =="
+DETECT_WORK="$(mktemp -d)"
+trap "rm -rf '$DETECT_WORK'" EXIT
+
+mkdir -p "$DETECT_WORK/venv-importable/bin" "$DETECT_WORK/venv-broken/bin" \
+         "$DETECT_WORK/path-importable"
+
+# Mock interpreter that pretends `python3 -c "import molecule_runtime"` succeeds.
+make_importable_python() {
+  cat > "$1" <<'PYEOF'
+#!/bin/bash
+case "$*" in
+  *"import molecule_runtime"*) exit 0 ;;
+  *) exit 1 ;;
+esac
+PYEOF
+  chmod +x "$1"
+}
+
+# Mock interpreter that always fails to import molecule_runtime (system python shape).
+make_broken_python() {
+  cat > "$1" <<'PYEOF'
+#!/bin/bash
+exit 1
+PYEOF
+  chmod +x "$1"
+}
+
+make_importable_python "$DETECT_WORK/venv-importable/bin/python3"
+make_broken_python     "$DETECT_WORK/venv-broken/bin/python3"
+make_importable_python "$DETECT_WORK/path-importable/python3"
+
+# F.1: venv path first, even when a working PATH python exists
+result=$(PATH="$DETECT_WORK/path-importable:/usr/bin:/bin" \
+  detect_python "$DETECT_WORK/venv-importable/bin/python3" python3)
+if [ "$result" = "$DETECT_WORK/venv-importable/bin/python3" ]; then
+  echo "  PASS  F.1: detect_python picks venv path BEFORE PATH python3"
+  PASS=$((PASS+1))
+else
+  echo "  FAIL  F.1: expected '$DETECT_WORK/venv-importable/bin/python3', got '$result'"
+  FAIL=$((FAIL+1))
+fi
+
+# F.2: venv-broken → falls through to PATH (mirrors a partially-installed AMI)
+result=$(PATH="$DETECT_WORK/path-importable:/usr/bin:/bin" \
+  detect_python "$DETECT_WORK/venv-broken/bin/python3" python3)
+if [ "$result" = "$DETECT_WORK/path-importable/python3" ]; then
+  echo "  PASS  F.2: detect_python falls through to PATH when venv python doesn't import"
+  PASS=$((PASS+1))
+else
+  echo "  FAIL  F.2: expected '$DETECT_WORK/path-importable/python3', got '$result'"
+  FAIL=$((FAIL+1))
+fi
+
+# F.3: nothing importable → returns empty (install.sh then logs the warning + skips block)
+result=$(PATH="/usr/bin:/bin" \
+  detect_python "$DETECT_WORK/venv-broken/bin/python3" /no/such/python)
+if [ -z "$result" ]; then
+  echo "  PASS  F.3: detect_python returns empty when no candidate imports molecule_runtime"
+  PASS=$((PASS+1))
+else
+  echo "  FAIL  F.3: expected empty, got '$result'"
+  FAIL=$((FAIL+1))
+fi
+
+# F.4: missing absolute candidate is skipped without erroring
+result=$(detect_python /no/such/python "$DETECT_WORK/venv-importable/bin/python3")
+if [ "$result" = "$DETECT_WORK/venv-importable/bin/python3" ]; then
+  echo "  PASS  F.4: detect_python skips non-existent absolute paths and continues"
+  PASS=$((PASS+1))
+else
+  echo "  FAIL  F.4: expected '$DETECT_WORK/venv-importable/bin/python3', got '$result'"
+  FAIL=$((FAIL+1))
+fi
+
+# F.5: empty PATH-resolved candidate (command -v miss) is skipped
+result=$(PATH="/empty-only" \
+  detect_python python3 "$DETECT_WORK/venv-importable/bin/python3")
+if [ "$result" = "$DETECT_WORK/venv-importable/bin/python3" ]; then
+  echo "  PASS  F.5: detect_python skips PATH candidates that command -v can't resolve"
+  PASS=$((PASS+1))
+else
+  echo "  FAIL  F.5: expected '$DETECT_WORK/venv-importable/bin/python3', got '$result'"
+  FAIL=$((FAIL+1))
+fi
+
 # --- Parity check: install.sh must contain the same anchor strings ---
 echo
 echo "== parity with install.sh =="
@@ -167,7 +282,9 @@ for pattern in \
   'WORKSPACE_ID:' \
   'PLATFORM_URL:' \
   'MOLECULE_ORG_ID:' \
-  'CONFIGS_DIR:'; do
+  'CONFIGS_DIR:' \
+  '/opt/molecule-venv/bin/python3' \
+  '/opt/molecule-venv/bin/python'; do
   if ! grep -F -q -- "$pattern" "$INSTALL"; then
     echo "  FAIL  install.sh missing substring: $pattern"
     PARITY_FAIL=$((PARITY_FAIL+1))
@@ -178,6 +295,22 @@ if [ "$PARITY_FAIL" -eq 0 ]; then
   PASS=$((PASS+1))
 else
   FAIL=$((FAIL+PARITY_FAIL))
+fi
+
+# Ordering invariant: venv candidates MUST appear BEFORE the PATH-based
+# `python3`/`python` lookup in install.sh's detection loop. Reverse the
+# order and the original silent-skip bug is back: command -v resolves
+# python3 first, /usr/bin/python3 has stdlib only, the import test fails
+# but the pre-fix loop returned the resolved path anyway. Pin the order.
+venv_line=$(grep -nE '/opt/molecule-venv/bin/python3' "$INSTALL" | head -1 | cut -d: -f1)
+path_line=$(grep -nE 'for candidate in' "$INSTALL" | head -1 | cut -d: -f1)
+if [ -n "$venv_line" ] && [ -n "$path_line" ] && [ "$venv_line" -ge "$path_line" ] \
+   && grep -E "for candidate in /opt/molecule-venv/bin/python3 /opt/molecule-venv/bin/python python3 python" "$INSTALL" >/dev/null; then
+  echo "  PASS  install.sh detection loop tries venv candidates before PATH names"
+  PASS=$((PASS+1))
+else
+  echo "  FAIL  install.sh detection loop has wrong candidate order or pattern (venv must come first)"
+  FAIL=$((FAIL+1))
 fi
 
 # --- Idempotency: install.sh's config.yaml emit is a single-block rewrite ---


### PR DESCRIPTION
## Summary

PR #43 fixed the silent-skip bug live but the existing test shorts the detection loop by setting \`MOLECULE_MCP_PYTHON\` directly (cases A–E). The candidate-walk that picks \`/opt/molecule-venv/bin/python3\` over the system python has no coverage — drift in candidate ordering would re-introduce the original "agent boots without list_peers" failure.

## What this adds

Mirror \`detect_python\` in the test (same shape as \`emit_mcp_block\`), plus 5 new cases (24 total assertions, was 17):

- **F.1** venv-importable python wins over PATH-importable python
- **F.2** venv-broken python falls through to PATH (partial-AMI shape)
- **F.3** nothing-importable returns empty (install.sh skips block)
- **F.4** missing absolute candidate is skipped, loop continues
- **F.5** PATH candidate that \`command -v\` can't resolve is skipped

Plus parity-grep additions:
- \`/opt/molecule-venv/bin/python3\` + \`/python\` added to the anchor-string list.
- Ordering invariant: install.sh's \`for candidate in ...\` line must list venv paths before \`python3\`/\`python\` names — pinned with an exact-pattern grep.

Tests use shim shell scripts as mock interpreters so they run on any CI runner without installing the runtime wheel or writing to \`/opt/molecule-venv\`.

## Test plan

- [x] \`bash scripts/test-install-mcp-wireup.sh\` → \`results: 24 passed, 0 failed\`
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)