### PR TITLE
chore(docker): digest-pin python:3.11-slim base (RFC #388 PR-2b)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,12 @@
-FROM python:3.11-slim
+# Pin by digest, not tag — avoids surprise base-bumps. Pairs with the
+# Trivy gate in molecule-ci/.github/workflows/publish-template-image.yml
+# (PR #35): pin avoids unexpected upgrade, Trivy catches if the pinned
+# digest accumulates fixable HIGH/CRITICAL vulns over time. Bump
+# deliberately by re-resolving:
+#   docker pull --platform linux/amd64 python:3.11-slim
+#   docker inspect --format='{{index .RepoDigests 0}}' python:3.11-slim
+# Last resolved: 2026-05-03 (RFC #388 PR-2b).
+FROM python:3.11-slim@sha256:6d85378d88a19cd4d76079817532d62232be95757cb45945a99fec8e8084b9c2
 
 # System deps:
 #   curl         — hermes installer + loopback health probe in start.sh


### PR DESCRIPTION
## Summary

Pin \`python:3.11-slim\` base by digest. Pairs with the Trivy HIGH/CRITICAL gate landed in [molecule-ci#35](https://github.com/Molecule-AI/molecule-ci/pull/35):

| Mechanism | Catches |
|---|---|
| **Digest pin** (this PR) | Surprise base-bumps — silent layer-set changes that have bitten the org repeatedly. |
| **Trivy gate** ([molecule-ci#35](https://github.com/Molecule-AI/molecule-ci/pull/35)) | Pinned digest accumulating fixable HIGH/CRITICAL vulns over time. |

Stable + scanned pair: deliberate upgrades only, detected drift on staleness.

## Bump procedure

Documented inline in the Dockerfile. Re-resolve when an Ubuntu/python respin lands a fix you want to consume:
\`\`\`
docker pull --platform linux/amd64 python:3.11-slim
docker inspect --format='{{index .RepoDigests 0}}' python:3.11-slim
\`\`\`

## Test plan

- [x] Diff is one-line code change + comment block (10 lines added)
- [ ] CI green on this branch (build still works against the pinned digest)

## Refs

- RFC: [#388](https://github.com/Molecule-AI/molecule-controlplane/issues/388) (v3 PR-2 unique work after #2275 covered most of bake-smoke)
- Trivy gate (companion): [molecule-ci#35](https://github.com/Molecule-AI/molecule-ci/pull/35)

🤖 Generated with [Claude Code](https://claude.com/claude-code)