### PR TITLE
perf(Dockerfile): reorder layers so hermes installer caches across .py edits

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,30 @@
 # Last resolved: 2026-05-03 (RFC #388 PR-2b).
 FROM python:3.11-slim@sha256:6d85378d88a19cd4d76079817532d62232be95757cb45945a99fec8e8084b9c2
 
+# ─────────────────────────────────────────────────────────────────────
+# CACHE-FRIENDLY LAYER ORDER — read before adding new layers.
+#
+# Layers are ordered slowest-and-most-stable → fastest-and-most-changing.
+# When `cache-from: type=gha` hits, Docker reuses the cached output of a
+# layer iff (a) its command text is identical AND (b) every prior layer
+# was also a cache hit. Any earlier layer that changes invalidates ALL
+# subsequent layers.
+#
+# The expensive layers are:
+#   1. apt-get install (build-essential + Node-tarball xz extractor)
+#   2. pip install -r requirements.txt
+#   3. curl|bash hermes-agent installer (downloads Node 22 ~140 MB +
+#      builds hermes-agent from source, ~2-4 min by itself)
+#   4. pip install hermes fork + platform plugin from git
+#
+# These ~rarely change (only on Dockerfile edits / requirements bumps /
+# fork-ref bumps) so they belong UP TOP. The cheap, high-churn `COPY *.py`
+# layers belong AT THE BOTTOM. Putting the hermes installer below the
+# COPYs caused every adapter.py / executor.py / scripts/ change to bust
+# its cache → 5-12 min publish-image runs (vs 1-3 min for sibling
+# templates). Don't move the COPYs back above the hermes install.
+# ─────────────────────────────────────────────────────────────────────
+
 # System deps:
 #   curl         — hermes installer + loopback health probe in start.sh
 #   ca-certificates — TLS for all the outbound installs
@@ -48,14 +72,12 @@ RUN pip install --no-cache-dir -r requirements.txt && \
       pip install --no-cache-dir --upgrade "molecule-ai-workspace-runtime==${RUNTIME_VERSION}"; \
     fi
 
-COPY adapter.py .
-COPY __init__.py .
-COPY executor.py .
-COPY scripts/ /app/scripts/
-COPY start.sh /usr/local/bin/start.sh
-RUN chmod +x /usr/local/bin/start.sh
-
 # --- Install the real Nous Research hermes-agent as the agent user ---
+# This MUST stay above the COPY *.py layers below (see cache-order
+# rationale at the top of the file). The installer text is fixed —
+# changing the upstream main branch will not invalidate the layer
+# unless you also touch the RUN command itself.
+#
 # The installer lives under the agent's home (~/.hermes, symlinks the
 # `hermes` entrypoint into ~/.local/bin/). Running as root would place
 # it in /root and break discovery.
@@ -96,8 +118,19 @@ RUN /home/agent/.hermes/hermes-agent/venv/bin/python3 -m ensurepip --upgrade && 
     /home/agent/.hermes/hermes-agent/venv/bin/python3 -m pip install --no-cache-dir \
       "git+https://github.com/Molecule-AI/hermes-platform-molecule-a2a.git@${HERMES_PLATFORM_MOLECULE_A2A_REF}#egg=hermes-platform-molecule-a2a"
 
+# ─────────────────────────────────────────────────────────────────────
+# Fast-changing layers — keep at the bottom.
+# Edits to adapter.py / executor.py / scripts/ / start.sh only invalidate
+# from here down (~5-10 s of work) instead of busting the hermes installer.
+# ─────────────────────────────────────────────────────────────────────
 USER root
 WORKDIR /app
+COPY adapter.py .
+COPY __init__.py .
+COPY executor.py .
+COPY scripts/ /app/scripts/
+COPY start.sh /usr/local/bin/start.sh
+RUN chmod +x /usr/local/bin/start.sh
 
 ENV ADAPTER_MODULE=adapter \
     HERMES_API_BASE=http://127.0.0.1:8642/v1 \


### PR DESCRIPTION
## Summary

- Moves the `curl|bash` hermes-agent installer + fork-patch install + plugin install ABOVE the `COPY adapter.py / executor.py / scripts/ / start.sh` block, so edits to those fast-changing files no longer bust the 2-4 min hermes installer cache layer.
- Adds a 23-line cache-order rationale comment block at the top of the Dockerfile so future maintainers don't accidentally move the COPYs back above the installer.

## Why

`publish-image.yml` runs at **5-12 min** for hermes vs **1-3 min** for codex / claude-code / openclaw, even though `cache-from: type=gha` is already wired in `molecule-ci/.github/workflows/publish-template-image.yml`. The cause: the Dockerfile placed the slowest layer (hermes-agent install: Node 22 ~140 MB + build from source) AFTER the fast-changing `COPY *.py` block, so any edit to `adapter.py` / `executor.py` / etc. invalidated the installer layer. After the reorder, only requirements.txt + Dockerfile-prefix changes invalidate the installer.

## Local verification

Cold build: succeeds clean. Smoke tests pass:
- `hermes --version` reports cleanly (Python 3.11.15, OpenAI SDK 2.33.0, project at venv/site-packages)
- `adapter` + `executor` import from `/app`
- Fork patch present (`register_platform_adapter` 5 occurrences in `hermes_cli.plugins`)
- `hermes_platform_molecule_a2a` plugin importable
- `start.sh` is executable, root-owned, `/app/scripts/` perms preserved

**Incremental build (touch `adapter.py` only): 1 second** — full cache hit on the hermes installer layer. Today this would re-run the full installer (~3-7 min for that layer alone).

## Expected impact in CI

Once merged, the **first** publish-image run on main will be a cold build (no benefit). All **subsequent** publish-image runs that touch only Python source files (the common edit shape — most commits) will hit the cached installer layer and complete in ~1-2 min instead of 5-12 min. Aligns hermes with the other 3 templates.

## Test plan

- [ ] CI publish-image on this PR succeeds (validates the new layer order against the GHA-cache-from path that wasn't tested locally)
- [ ] Bake-time smoke (executor.execute() smoke + module-import + bare-import gate) all pass
- [ ] After merge, observe the next 2-3 publish-image runs on main — expect 1-2 min once the new cache layer is seeded
- [ ] After merge + 1 publish cycle, run a no-op edit (touch a .py file, push) — expect <2 min total

## Notes

- No Dockerfile content changes other than the layer order + the new comment block. Same base image (`python:3.11-slim` digest-pinned), same hermes installer URL, same fork ref args, same final ENV + ENTRYPOINT.
- The `USER agent → USER root` transition is preserved: hermes installer still runs as `agent`, COPYs run as `root`, ENTRYPOINT runs as `root` (which then `gosu agent`s in start.sh).

🤖 Generated with [Claude Code](https://claude.com/claude-code)