### PR TITLE
fix(start.sh): move hermes gateway log into HERMES_HOME for stable perms

### DIFF
--- a/start.sh
+++ b/start.sh
@@ -48,11 +48,23 @@ echo "------------------------------------------------"
 HERMES_HOME="/tmp/.hermes"
 ENV_FILE="${HERMES_HOME}/.env"
 HERMES_CONFIG="${HERMES_HOME}/config.yaml"
-LOG_FILE="/tmp/hermes-gateway.log"
-
-mkdir -p "$(dirname "$LOG_FILE")"
-touch "$LOG_FILE"
-chown agent:agent "$LOG_FILE"
+# LOG_FILE lives inside HERMES_HOME so the `install -d -o agent` below
+# is the single source of permission. The earlier
+# `LOG_FILE="/tmp/hermes-gateway.log"` plus `touch + chown` pattern
+# created a race surface: the gateway is spawned under `gosu agent` with
+# the redirect `>>"$LOG_FILE"` parsed by the root parent shell, but the
+# file's effective writability was sensitive to whatever order the
+# touch/chown pair completed in (and which cgroup user-namespace
+# remapping the runtime layered on top). Symptom in production:
+# repeated `start.sh: line 282: /tmp/hermes-gateway.log: Permission
+# denied` followed by `[start.sh] hermes gateway exited during boot`,
+# never reaching agent-card readiness — exactly what bench run
+# 25320395954's hermes job hit on 2026-05-04 after the runtime image
+# pin engaged the containerized path. Putting the log under HERMES_HOME
+# means the agent-owned directory tree contains an agent-owned file,
+# and root's redirect into a directory it owns transitively works
+# regardless of file-vs-directory ownership ordering quirks.
+LOG_FILE="${HERMES_HOME}/gateway.log"
 
 # --- Generate a per-container API_SERVER_KEY ---
 # hermes-agent requires a bearer token on the api-server platform. We
@@ -64,6 +76,12 @@ if [ -z "${API_SERVER_KEY:-}" ]; then
 fi
 
 install -d -o agent -g agent "$HERMES_HOME"
+# Atomic create-with-perms for LOG_FILE — same ownership semantics as
+# HERMES_HOME above. install(1) creates the file in one syscall with
+# mode + owner set, eliminating the touch-then-chown race that bit the
+# old `/tmp/hermes-gateway.log` placement (see comment at LOG_FILE
+# definition above).
+install -m 644 -o agent -g agent /dev/null "$LOG_FILE"
 
 # --- Write hermes-agent's .env ---
 # API_SERVER_ENABLED must be true and the bearer must match. Every


### PR DESCRIPTION
## Summary

Move the hermes gateway log from \`/tmp/hermes-gateway.log\` (chowned manually after touch) to \`/tmp/.hermes/gateway.log\` (inside HERMES_HOME, which is properly \`install -d -o agent -g agent\` from the start). Also switch to \`install -m 644 -o agent -g agent /dev/null\` for atomic create-with-perms.

## Why

[bench-provision-time run 25320395954](https://github.com/Molecule-AI/molecule-controlplane/actions/runs/25320395954)'s hermes matrix job hit:

\`\`\`
/usr/local/bin/start.sh: line 282: /tmp/hermes-gateway.log: Permission denied
[start.sh] hermes gateway exited during boot.
\`\`\`

This was the **first time hermes booted on the containerized path** (runtime_image_pins row was added at 12:46Z earlier today as part of the RFC #388 thin-AMI loop). Previously hermes only ran the legacy clone+install.sh path, which doesn't use this log file at all — so the bug was latent for as long as start.sh has had this code.

Root cause: the redirect on line 282 (\`>>\"\$LOG_FILE\"\`) is parsed by the **root parent shell** before the gosu drop, but the file lives outside the agent-owned HERMES_HOME tree. The touch-then-chown sequence + runtime user-namespace remapping (Docker can shift UIDs in the container's view of the filesystem) leaves the redirect hitting EACCES.

Putting LOG_FILE inside HERMES_HOME means the agent-owned directory tree contains an agent-owned file. Root's redirect into a directory tree it implicitly has access to works without the file-vs-directory ownership ordering quirks.

## Verification

- [x] \`bash -n start.sh\` syntax-clean
- [x] No content change to the redirect itself, just location + creation mode
- [ ] After merge: new image publishes; re-pin hermes runtime image to new digest; re-bench. With a hermes-compatible API key (MINIMAX, ANTHROPIC, etc.) in workspace env, /health should bind in <120s.

## Out of scope

The auto-select-model-without-key logic in start.sh (\`'no model env was set; auto-selected ... from available API keys'\`) is structurally awkward — it picks a model even when ALL provider keys are unset, then hermes-agent crashes at request time. Worth a separate small PR to make the no-key case a clean exit with a clear message instead of a misleading \"auto-selected\" log line. Not blocking this fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)