### PR TITLE
fix(start): race molecule-runtime with hermes gateway instead of gating exec

### DIFF
--- a/adapter.py
+++ b/adapter.py
@@ -15,8 +15,10 @@ docs/PLANNING.md for the rewrite rationale.
 """
 from __future__ import annotations
 
+import asyncio
 import logging
 import os
+import time
 
 from molecule_runtime.adapters.base import BaseAdapter, AdapterConfig, RuntimeCapabilities
 
@@ -243,17 +245,49 @@ class HermesAgentAdapter(BaseAdapter):
             health_url = base.replace("/v1", "") + "/health"
             err_hint = "Check /var/log/hermes-gateway.log inside the container."
 
+        # Retry the gateway probe with linear backoff up to a configurable
+        # budget. start.sh used to gate `exec molecule-runtime` on the
+        # gateway being healthy; that gate was removed (see start.sh's
+        # "Race molecule-runtime with hermes gateway" block) so this probe
+        # now runs against a still-warming-up gateway. Budget defaults to
+        # 120s which matches the old in-shell wait — operators can shrink
+        # it to fail-fast (development) or extend it (slow first-boot DB
+        # migrations) via HERMES_GATEWAY_READY_BUDGET_SEC.
+        #
         # AsyncClient — sync httpx inside an async setup() can deadlock
         # against an aiohttp server sharing the same event loop (only
         # bites in tests; real deployments separate processes).
         try:
-            async with httpx.AsyncClient(timeout=5.0) as client:
-                r = await client.get(health_url)
-                r.raise_for_status()
-        except Exception as exc:  # pragma: no cover
+            budget_sec = int(os.environ.get("HERMES_GATEWAY_READY_BUDGET_SEC", "120"))
+        except ValueError:
+            budget_sec = 120
+        deadline = time.monotonic() + max(budget_sec, 5)
+        last_exc: Exception | None = None
+        attempt = 0
+        async with httpx.AsyncClient(timeout=5.0) as client:
+            while time.monotonic() < deadline:
+                attempt += 1
+                try:
+                    r = await client.get(health_url)
+                    r.raise_for_status()
+                    if attempt > 1:
+                        elapsed = budget_sec - max(0, int(deadline - time.monotonic()))
+                        logger.info(
+                            "hermes gateway probe succeeded after %d attempt(s) (~%ds elapsed)",
+                            attempt, elapsed,
+                        )
+                    last_exc = None
+                    break
+                except Exception as exc:  # noqa: BLE001
+                    last_exc = exc
+                    if time.monotonic() + 2 >= deadline:
+                        break
+                    await asyncio.sleep(2)
+        if last_exc is not None:  # pragma: no cover
             raise RuntimeError(
-                f"hermes-agent surface not reachable at {health_url}. {err_hint}"
-            ) from exc
+                f"hermes-agent surface not reachable at {health_url} after "
+                f"{attempt} attempt(s) over ~{budget_sec}s. {err_hint}"
+            ) from last_exc
 
     async def create_executor(self, config: AdapterConfig):
         from executor import HermesAgentProxyExecutor

--- a/start.sh
+++ b/start.sh
@@ -302,30 +302,27 @@ nohup gosu agent env HOME=/tmp PATH="/home/agent/.local/bin:/usr/local/sbin:/usr
     >>"$LOG_FILE" 2>&1 &
 GATEWAY_PID=$!
 
-# --- Wait for :8642 readiness ---
-# Max 120s — enough for a cold gateway boot including first-time DB
-# migrations and session-store init. Longer waits should surface as a
-# provisioning failure upstream rather than silently holding the container.
-READY_TIMEOUT=120
-for _ in $(seq 1 $READY_TIMEOUT); do
-  if curl -fsS "http://127.0.0.1:${API_SERVER_PORT:-8642}/health" >/dev/null 2>&1; then
-    break
-  fi
-  if ! kill -0 "$GATEWAY_PID" 2>/dev/null; then
-    echo "[start.sh] hermes gateway exited during boot. Last log lines:" >&2
-    tail -40 "$LOG_FILE" >&2
-    exit 1
-  fi
-  sleep 1
-done
-
-if ! curl -fsS "http://127.0.0.1:${API_SERVER_PORT:-8642}/health" >/dev/null 2>&1; then
-  echo "[start.sh] hermes gateway failed to reach /health within ${READY_TIMEOUT}s." >&2
-  tail -80 "$LOG_FILE" >&2
-  exit 1
-fi
-
-echo "[start.sh] hermes gateway ready on :${API_SERVER_PORT:-8642} (pid ${GATEWAY_PID})"
+# --- Race molecule-runtime with hermes gateway ---
+# Previously this script waited up to 120s for hermes-gateway /health
+# before exec'ing molecule-runtime, then exited 1 on timeout. That coupled
+# the workspace's READINESS (`/.well-known/agent-card.json` returning 200)
+# to hermes-gateway being healthy — which itself depends on valid LLM
+# credentials. Result: a workspace launched without MINIMAX/OPENAI/etc.
+# crash-looped silently and `/agent-card` never served, blocking deprovision
+# and giving canvas no actionable signal. Fixed in tandem with molecule-core
+# PR #2756 which decoupled `adapter.setup()` from agent-card mounting.
+#
+# New shape: hermes-gateway runs in the background; molecule-runtime exec's
+# immediately. The Python adapter (`adapter.py:setup()`) probes :8642/health
+# with retry+backoff up to HERMES_GATEWAY_READY_BUDGET_SEC (default 120s).
+# - Healthy gateway → adapter.setup() probe succeeds → DefaultRequestHandler
+#   mounts → agent works as before, with /agent-card served seconds earlier
+#   than the old wait-then-exec path.
+# - Broken gateway → adapter.setup() probe exhausts retries → main.py mounts
+#   the not-configured handler → /agent-card still 200, JSON-RPC returns
+#   `-32603 "agent not configured"` with the gateway-not-reachable error
+#   string, canvas can render a clear error to the user.
+echo "[start.sh] hermes gateway backgrounded (pid ${GATEWAY_PID}); molecule-runtime will probe :${API_SERVER_PORT:-8642}/health on its own retry budget."
 
 # --- Exec molecule-runtime on :8000 ---
 # From here on, every A2A message the platform sends gets proxied

--- a/tests/test_adapter.py
+++ b/tests/test_adapter.py
@@ -132,6 +132,122 @@ async def test_setup_probes_chat_completions_health_when_disabled(monkeypatch):
     assert paths_hit == ["/health"]
 
 
+# ---- setup() retry-with-backoff ---------------------------------------
+# The probe used to be single-shot with a 5s timeout because start.sh
+# only exec'd molecule-runtime AFTER hermes-gateway was healthy. start.sh
+# now backgrounds the gateway and exec's molecule-runtime immediately
+# (race shape, see start.sh "Race molecule-runtime with hermes gateway"
+# block + hermes-template#50). The adapter's probe handles the
+# synchronization with retry + linear backoff up to a configurable budget.
+
+
+@pytest.mark.asyncio
+async def test_setup_retries_until_gateway_becomes_healthy(monkeypatch):
+    """Gateway slow to come up: probe fails first attempt, succeeds
+    on a later one within the budget. setup() returns successfully —
+    operator's workspace works as soon as gateway is ready, no
+    crash-and-restart required."""
+    monkeypatch.delenv("MOLECULE_SMOKE_MODE", raising=False)
+    monkeypatch.setenv("MOLECULE_A2A_PLATFORM_ENABLED", "false")
+    monkeypatch.setenv("HERMES_GATEWAY_READY_BUDGET_SEC", "30")
+
+    api_port = _free_port()
+    state = {"started": False}
+    paths_hit: list[str] = []
+
+    async def health_handler(request: web.Request) -> web.Response:
+        paths_hit.append(request.path)
+        if not state["started"]:
+            return web.Response(status=503)  # gateway warming up
+        return web.json_response({"status": "ok"})
+
+    app = web.Application()
+    app.router.add_get("/health", health_handler)
+    runner = web.AppRunner(app)
+    await runner.setup()
+    site = web.TCPSite(runner, "127.0.0.1", api_port)
+    await site.start()
+
+    try:
+        monkeypatch.setenv("HERMES_API_BASE", f"http://127.0.0.1:{api_port}/v1")
+        # Flip "started" after a couple of probe failures so the retry
+        # loop actually exercises its retry path. The retry sleep is 2s,
+        # so flipping after a small delay lets attempt 2 or 3 succeed.
+        async def flip_after_delay():
+            import asyncio as _asyncio
+            await _asyncio.sleep(2.5)
+            state["started"] = True
+
+        import asyncio as _asyncio
+        flip_task = _asyncio.create_task(flip_after_delay())
+
+        cfg = AdapterConfig(model="hermes-test")
+        await HermesAgentAdapter().setup(cfg)
+
+        await flip_task
+    finally:
+        await site.stop()
+        await runner.cleanup()
+
+    # We saw at least 2 probes (one failure + one success).
+    assert len(paths_hit) >= 2
+    assert paths_hit[-1] == "/health"
+
+
+@pytest.mark.asyncio
+async def test_setup_raises_after_budget_exhausted(monkeypatch):
+    """Gateway never becomes healthy: probe retries exhaust the budget,
+    setup() raises RuntimeError with a helpful "after N attempt(s) over
+    ~Ns" message. main.py's PR #2756 try/except mounts the not-configured
+    handler so /agent-card stays 200 — operator sees a clean -32603 with
+    the gateway-not-reachable reason."""
+    monkeypatch.delenv("MOLECULE_SMOKE_MODE", raising=False)
+    monkeypatch.setenv("MOLECULE_A2A_PLATFORM_ENABLED", "false")
+    # Tight budget so the test runs in seconds, not minutes.
+    monkeypatch.setenv("HERMES_GATEWAY_READY_BUDGET_SEC", "5")
+
+    # Point at a port where nothing is listening — every probe fails.
+    monkeypatch.setenv("HERMES_API_BASE", f"http://127.0.0.1:{_free_port()}/v1")
+
+    cfg = AdapterConfig(model="hermes-test")
+    with pytest.raises(RuntimeError, match=r"hermes-agent surface not reachable.*attempt"):
+        await HermesAgentAdapter().setup(cfg)
+
+
+@pytest.mark.asyncio
+async def test_setup_invalid_budget_falls_back_to_default(monkeypatch):
+    """Garbage in HERMES_GATEWAY_READY_BUDGET_SEC must not crash setup()
+    with a ValueError — fall back to the 120s default. Operators
+    misconfigure env vars; the runtime should be resilient.
+
+    We don't actually wait 120s here — the test points at a port with
+    a server that responds 200 immediately, so the probe succeeds on
+    attempt 1 regardless of the budget value."""
+    monkeypatch.delenv("MOLECULE_SMOKE_MODE", raising=False)
+    monkeypatch.setenv("MOLECULE_A2A_PLATFORM_ENABLED", "false")
+    monkeypatch.setenv("HERMES_GATEWAY_READY_BUDGET_SEC", "not-an-int")
+
+    api_port = _free_port()
+
+    async def health_handler(request: web.Request) -> web.Response:
+        return web.json_response({"status": "ok"})
+
+    app = web.Application()
+    app.router.add_get("/health", health_handler)
+    runner = web.AppRunner(app)
+    await runner.setup()
+    site = web.TCPSite(runner, "127.0.0.1", api_port)
+    await site.start()
+
+    try:
+        monkeypatch.setenv("HERMES_API_BASE", f"http://127.0.0.1:{api_port}/v1")
+        cfg = AdapterConfig(model="hermes-test")
+        await HermesAgentAdapter().setup(cfg)  # no exception
+    finally:
+        await site.stop()
+        await runner.cleanup()
+
+
 # ---- create_executor lifecycle ---------------------------------------
 
 


### PR DESCRIPTION
## Summary

Closes #50. Pairs with molecule-core PR #2756 (decoupled adapter.setup() from agent-card mounting).

## The bug

\`start.sh\` waited up to 120s for \`hermes gateway\` /health before exec'ing molecule-runtime, then exited 1 on timeout. This coupled the workspace's READINESS (\`/.well-known/agent-card.json\` returning 200) to hermes-gateway being healthy — which itself depends on valid LLM credentials. A workspace launched without MINIMAX/OPENAI/etc. crash-looped silently, /agent-card never served, canvas had no actionable signal.

Caught during the RFC #388 strict <120s bench (run 25330411657 on 2026-05-04): hermes ran 290s while claude-code hit 56.8s on the same AMI. The 290s overhead was the start.sh gateway gate looping until the gateway eventually settled.

## The fix

Two changes, applied together:

### \`start.sh\`
Background hermes-gateway; \`exec molecule-runtime\` immediately. No 120s wait, no exit-on-timeout. molecule-runtime starts binding /agent-card right away.

### \`adapter.py\` setup()
Probe :8642/health with retry + 2s linear backoff, configurable budget via \`HERMES_GATEWAY_READY_BUDGET_SEC\` (default 120s, matches the old in-shell wait). If the budget exhausts, raise with \"after N attempt(s) over ~Ns\" — molecule-core's PR #2756 try/except mounts the not-configured handler so /agent-card stays 200 and JSON-RPC returns -32603 with this reason.

## Bench expectation

Hermes should drop from 290s → claude-code class (~50–80s) since /agent-card now serves the moment uvicorn binds, not after the 120s gateway gate.

## Test plan

3 new tests in \`tests/test_adapter.py\`:
- [x] **retries_until_gateway_becomes_healthy**: gateway flips from 503→200 mid-probe; setup succeeds.
- [x] **raises_after_budget_exhausted**: nothing listening on the port; budget=5s; setup raises with the expected error.
- [x] **invalid_budget_falls_back_to_default**: garbage in env var doesn't crash setup() with ValueError.

All 47 existing tests pass. Manual verification via the bench-provision-time workflow once this lands + AMI re-bake.

🤖 Generated with [Claude Code](https://claude.com/claude-code)