### PR TITLE
fix(start.sh): supervise hermes-gateway — restart on crash, cap restart loops

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,3 +26,4 @@ jobs:
       - run: bash scripts/test-install-prefix-strip.sh
       - run: bash scripts/test-load-workspace-config.sh
       - run: bash scripts/test-install-mcp-wireup.sh
+      - run: bash scripts/test-gateway-supervisor.sh

--- a/scripts/gateway-supervisor.sh
+++ b/scripts/gateway-supervisor.sh
@@ -1,0 +1,109 @@
+#!/usr/bin/env bash
+# Spawn + supervise the hermes-agent gateway process.
+#
+# Why this is its own file: PR #51 made start.sh exec ``molecule-runtime``
+# immediately after backgrounding hermes gateway, so a mid-run crash of
+# the gateway would leave molecule-runtime serving /agent-card 200 while
+# every JSON-RPC call silently failed (executor proxies to :8642, which
+# is dead). The supervisor closes that gap by polling the gateway PID
+# and respawning on death, capped to avoid restart loops on persistent
+# auth/config failures.
+#
+# Sourced by start.sh — exposes two functions:
+#
+#   spawn_gateway <log_file>
+#       nohup-spawns ``hermes gateway`` under gosu agent with the
+#       fixed PATH from start.sh's environment. Sets the GATEWAY_PID
+#       global to the spawned pid. Idempotent: callers can invoke it
+#       again to respawn.
+#
+#   supervise_gateway <log_file>
+#       Backgrounded supervisor loop. Polls GATEWAY_PID every
+#       ``HERMES_GATEWAY_SUPERVISOR_POLL_SEC`` seconds (default 5).
+#       On dead PID: spawn_gateway respawns, restart counter increments.
+#       Exits the supervisor subshell when restarts exceed
+#       ``HERMES_GATEWAY_MAX_RESTARTS`` (default 5) inside a rolling
+#       ``HERMES_GATEWAY_RESTART_WINDOW_SEC`` window (default 300s).
+#       Set ``HERMES_GATEWAY_SUPERVISOR_DISABLE=1`` to skip the
+#       supervisor entirely (escape hatch for debugging or for runs
+#       where the operator wants the legacy "container dies on first
+#       gateway crash" behavior).
+#
+# All knobs default to values that match the old in-shell wait budget
+# (5×60s ≈ 5min upper bound for transient gateway flapping); operators
+# can tune via env without re-baking the image.
+
+set -u
+
+# spawn_gateway <log_file>
+#
+# Spawn hermes-gateway as a backgrounded child of the calling shell.
+# Sets GATEWAY_PID to the new pid. The HOME=/tmp + explicit PATH match
+# the original start.sh invocation — see the "Start hermes gateway in
+# the background" block in start.sh for the rationale (HERMES_HOME
+# resolution + read-only PATH lookup under T1 sandbox).
+spawn_gateway() {
+  local log_file="$1"
+  nohup gosu agent env HOME=/tmp \
+      PATH="/home/agent/.local/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin" \
+      bash -c "cd /tmp && hermes gateway" \
+      >>"${log_file}" 2>&1 &
+  GATEWAY_PID=$!
+}
+
+# supervise_gateway <log_file>
+#
+# Run the supervisor loop. Caller should backgound this with `&` and
+# leave it running; on container death the supervisor dies with the
+# parent.
+#
+# The rolling window resets the restart counter when window_sec elapses
+# without exhaustion. Without that, a single transient crash early in
+# the workspace's life would count against a much-later crash and cause
+# a healthy long-running workspace to die on its sixth lifetime
+# restart. Counting restarts within a window matches the Linux
+# `systemd` Restart= semantics and the Kubernetes BackOff cap pattern.
+supervise_gateway() {
+  local log_file="$1"
+
+  if [ "${HERMES_GATEWAY_SUPERVISOR_DISABLE:-}" = "1" ]; then
+    echo "[start.sh:supervisor] HERMES_GATEWAY_SUPERVISOR_DISABLE=1 — skipping supervisor; gateway crashes will not auto-restart." >&2
+    return 0
+  fi
+
+  local max_restarts="${HERMES_GATEWAY_MAX_RESTARTS:-5}"
+  local window_sec="${HERMES_GATEWAY_RESTART_WINDOW_SEC:-300}"
+  local poll_sec="${HERMES_GATEWAY_SUPERVISOR_POLL_SEC:-5}"
+
+  local restarts=0
+  local window_start
+  window_start="$(date +%s)"
+
+  while true; do
+    sleep "${poll_sec}"
+
+    # Reset rolling window if it has elapsed without exhaustion.
+    local now
+    now="$(date +%s)"
+    if [ "$((now - window_start))" -ge "${window_sec}" ]; then
+      restarts=0
+      window_start="${now}"
+    fi
+
+    # Live-PID check. kill -0 is a permission/existence probe that
+    # doesn't actually signal — just tells us if the process still
+    # exists in the kernel's pid table.
+    if kill -0 "${GATEWAY_PID}" 2>/dev/null; then
+      continue
+    fi
+
+    restarts=$((restarts + 1))
+    if [ "${restarts}" -gt "${max_restarts}" ]; then
+      echo "[start.sh:supervisor] hermes gateway exceeded ${max_restarts} restarts within ${window_sec}s; giving up. Workspace will continue serving /agent-card but JSON-RPC will fail until the next container restart." >&2
+      return 0
+    fi
+
+    echo "[start.sh:supervisor] hermes gateway died (pid was ${GATEWAY_PID}); restart attempt ${restarts} of ${max_restarts}" >&2
+    spawn_gateway "${log_file}"
+  done
+}

--- a/scripts/test-gateway-supervisor.sh
+++ b/scripts/test-gateway-supervisor.sh
@@ -1,0 +1,274 @@
+#!/usr/bin/env bash
+# tests/test_gateway_supervisor.sh — bash assertion tests for
+# scripts/gateway-supervisor.sh.
+#
+# We mock `gosu`, `bash`, `hermes`, and `nohup` by prepending a tmp dir
+# to PATH containing scripts of those names that behave deterministically
+# (the "gateway" simulates a child process that lives for a controlled
+# duration, then exits, so the supervisor's dead-PID detection can be
+# exercised without waiting on real hermes-agent).
+#
+# Run with:   bash tests/test_gateway_supervisor.sh
+# Exit code:  0 on success, 1 on any failure.
+#
+# No bats / pytest deps — same convention as test_derive_provider.sh.
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+SUPERVISOR="${SCRIPT_DIR}/scripts/gateway-supervisor.sh"
+
+if [ ! -f "${SUPERVISOR}" ]; then
+  echo "FAIL: cannot find gateway-supervisor.sh at ${SUPERVISOR}" >&2
+  exit 1
+fi
+
+PASS=0
+FAIL=0
+FAILURES=()
+
+ok() {
+  local name="$1"
+  PASS=$((PASS + 1))
+  printf "  PASS  %s\n" "${name}"
+}
+
+bad() {
+  local name="$1"
+  local detail="$2"
+  FAIL=$((FAIL + 1))
+  FAILURES+=("${name}: ${detail}")
+  printf "  FAIL  %s — %s\n" "${name}" "${detail}"
+}
+
+# Set up a tmp dir with shimmed `gosu`, `bash`, `hermes` so spawn_gateway
+# can run without root + without a real hermes binary. The shims live
+# only for this test and are PATH-prepended.
+TMP_DIR="$(mktemp -d)"
+# Belt-and-suspenders cleanup: respawned (nohup'd, HUP-immune) gateways
+# outlive their parent supervisor and would otherwise write to a freed
+# log path after TMP_DIR is gone, surfacing as "No such file or directory"
+# noise in CI output. pkill -P kills every descendant of this test
+# process; the rm follows.
+cleanup_at_exit() {
+  pkill -P $$ 2>/dev/null || true
+  sleep 0.2
+  rm -rf "${TMP_DIR}"
+}
+trap cleanup_at_exit EXIT
+
+# `gosu agent <cmd...>` → just runs <cmd...> (the privilege drop is
+# a no-op in tests). `env HOME=/tmp PATH=... bash -c "..."` would normally
+# follow; our shim forwards.
+cat > "${TMP_DIR}/gosu" <<'EOF'
+#!/usr/bin/env bash
+# Shim: `gosu <user> <cmd...>` → exec <cmd...>
+shift  # drop the user
+exec "$@"
+EOF
+chmod +x "${TMP_DIR}/gosu"
+
+# `hermes gateway` simulates a child that lives for HERMES_GATEWAY_LIFE_SEC
+# (default 60) then exits. The supervisor detects the exit via kill -0.
+# Defaulting to a long life means the cold-start test ("supervisor doesn't
+# spuriously restart a healthy gateway") sees stable behavior.
+cat > "${TMP_DIR}/hermes" <<'EOF'
+#!/usr/bin/env bash
+# Shim: `hermes gateway` → sleep then exit. Tests override
+# HERMES_GATEWAY_LIFE_SEC to control crash timing.
+if [ "${1:-}" = "gateway" ]; then
+  sleep "${HERMES_GATEWAY_LIFE_SEC:-60}"
+  exit 0
+fi
+exit 0
+EOF
+chmod +x "${TMP_DIR}/hermes"
+
+export PATH="${TMP_DIR}:${PATH}"
+
+LOG_FILE="${TMP_DIR}/gateway.log"
+touch "${LOG_FILE}"
+
+# Kill any orphan gateway processes from prior subtests so they don't
+# write to LOG_FILE during the next test's setup, which races with
+# nohup's redirect-open and surfaces as a confusing "No such file or
+# directory" stderr.
+reap_orphans() {
+  pkill -P $$ 2>/dev/null || true
+  sleep 0.2
+}
+
+# --- Test: spawn_gateway sets GATEWAY_PID to a live process ---
+test_spawn_sets_pid() {
+  local name="spawn_gateway sets GATEWAY_PID to live pid"
+  GATEWAY_PID=""
+  HERMES_GATEWAY_LIFE_SEC=10 spawn_gateway "${LOG_FILE}"
+  if [ -z "${GATEWAY_PID}" ]; then
+    bad "${name}" "GATEWAY_PID was not set"
+    return
+  fi
+  if ! kill -0 "${GATEWAY_PID}" 2>/dev/null; then
+    bad "${name}" "GATEWAY_PID=${GATEWAY_PID} but process is not alive"
+    return
+  fi
+  # Cleanup
+  kill "${GATEWAY_PID}" 2>/dev/null || true
+  wait "${GATEWAY_PID}" 2>/dev/null || true
+  ok "${name}"
+}
+
+# --- Test: supervisor restarts gateway when it dies ---
+test_supervisor_restarts_on_death() {
+  local name="supervisor respawns gateway on death within cap"
+
+  # Spawn a short-lived gateway (lives 2s, then exits).
+  GATEWAY_PID=""
+  HERMES_GATEWAY_LIFE_SEC=2 spawn_gateway "${LOG_FILE}"
+  local first_pid="${GATEWAY_PID}"
+
+  # Run supervisor in background with a 1s poll. After 4s the first
+  # gateway has died and the supervisor should have respawned it.
+  local sup_log
+  sup_log="$(mktemp)"
+  (
+    # Clear inherited EXIT trap so this subshell exiting doesn't wipe
+    # TMP_DIR (which would race with subsequent test setups).
+    trap - EXIT
+    HERMES_GATEWAY_SUPERVISOR_POLL_SEC=1 \
+    HERMES_GATEWAY_MAX_RESTARTS=3 \
+    HERMES_GATEWAY_RESTART_WINDOW_SEC=60 \
+    HERMES_GATEWAY_LIFE_SEC=10 \
+    supervise_gateway "${LOG_FILE}" 2>"${sup_log}"
+  ) &
+  local sup_pid=$!
+
+  sleep 5
+
+  # GATEWAY_PID at this point should be the RESPAWNED pid (a child of the
+  # supervisor subshell, not the original). The original first_pid should
+  # be dead. Read GATEWAY_PID from the supervisor's stderr — when it
+  # respawns, it logs "restart attempt N of M".
+  if ! grep -q "restart attempt 1 of 3" "${sup_log}"; then
+    bad "${name}" "supervisor did not log restart attempt; stderr: $(cat "${sup_log}")"
+    kill "${sup_pid}" 2>/dev/null || true
+    rm -f "${sup_log}"
+    return
+  fi
+
+  # Original gateway should be dead.
+  if kill -0 "${first_pid}" 2>/dev/null; then
+    bad "${name}" "original gateway pid ${first_pid} still alive — test setup bug"
+    kill "${first_pid}" "${sup_pid}" 2>/dev/null || true
+    rm -f "${sup_log}"
+    return
+  fi
+
+  # Cleanup
+  kill "${sup_pid}" 2>/dev/null || true
+  wait "${sup_pid}" 2>/dev/null || true
+  rm -f "${sup_log}"
+  ok "${name}"
+}
+
+# --- Test: supervisor exits cleanly after restart cap exhausted ---
+test_supervisor_caps_restarts() {
+  local name="supervisor exits after exceeding HERMES_GATEWAY_MAX_RESTARTS"
+
+  # Spawn a gateway that crashes immediately (life=0 means sleep 0, exit).
+  # The supervisor will respawn forever in the absence of a cap; with
+  # cap=2 it should exit cleanly after 2 restart attempts.
+  GATEWAY_PID=""
+  HERMES_GATEWAY_LIFE_SEC=0 spawn_gateway "${LOG_FILE}"
+
+  local sup_log
+  sup_log="$(mktemp)"
+  local sup_start
+  sup_start="$(date +%s)"
+
+  # Run supervisor in foreground (subshell). Cap=2, poll=1, window=60s.
+  # Expected: supervisor logs 2 restart attempts, then "exceeded" on the
+  # third dead-PID check, then returns. Total wall clock ≤ 8s on a
+  # responsive runner.
+  (
+    trap - EXIT
+    HERMES_GATEWAY_SUPERVISOR_POLL_SEC=1 \
+    HERMES_GATEWAY_MAX_RESTARTS=2 \
+    HERMES_GATEWAY_RESTART_WINDOW_SEC=60 \
+    HERMES_GATEWAY_LIFE_SEC=0 \
+    supervise_gateway "${LOG_FILE}" 2>"${sup_log}"
+  )
+
+  local sup_end
+  sup_end="$(date +%s)"
+  local elapsed=$((sup_end - sup_start))
+
+  if ! grep -q "exceeded 2 restarts" "${sup_log}"; then
+    bad "${name}" "supervisor did not log 'exceeded' message; stderr: $(cat "${sup_log}")"
+    rm -f "${sup_log}"
+    return
+  fi
+
+  if [ "${elapsed}" -gt 15 ]; then
+    bad "${name}" "supervisor took ${elapsed}s to exit; expected <15s"
+    rm -f "${sup_log}"
+    return
+  fi
+
+  rm -f "${sup_log}"
+  ok "${name}"
+}
+
+# --- Test: HERMES_GATEWAY_SUPERVISOR_DISABLE=1 short-circuits ---
+test_supervisor_disable_flag() {
+  local name="HERMES_GATEWAY_SUPERVISOR_DISABLE=1 returns immediately"
+  local sup_log
+  sup_log="$(mktemp)"
+
+  local sup_start
+  sup_start="$(date +%s)"
+  HERMES_GATEWAY_SUPERVISOR_DISABLE=1 supervise_gateway "${LOG_FILE}" 2>"${sup_log}"
+  local sup_end
+  sup_end="$(date +%s)"
+
+  local elapsed=$((sup_end - sup_start))
+
+  if ! grep -q "skipping supervisor" "${sup_log}"; then
+    bad "${name}" "expected 'skipping supervisor' log line; got: $(cat "${sup_log}")"
+    rm -f "${sup_log}"
+    return
+  fi
+  if [ "${elapsed}" -gt 2 ]; then
+    bad "${name}" "disable flag took ${elapsed}s to return; expected <2s"
+    rm -f "${sup_log}"
+    return
+  fi
+  rm -f "${sup_log}"
+  ok "${name}"
+}
+
+# --- Run all tests ---
+echo "== gateway-supervisor.sh tests =="
+
+# Source the supervisor functions into this shell.
+# shellcheck disable=SC1090
+. "${SUPERVISOR}"
+
+test_spawn_sets_pid
+reap_orphans
+test_supervisor_disable_flag
+reap_orphans
+test_supervisor_restarts_on_death
+reap_orphans
+test_supervisor_caps_restarts
+reap_orphans
+
+echo ""
+echo "Results: ${PASS} passed, ${FAIL} failed"
+if [ "${FAIL}" -gt 0 ]; then
+  echo "Failures:"
+  for f in "${FAILURES[@]}"; do
+    echo "  - ${f}"
+  done
+  exit 1
+fi
+exit 0

--- a/start.sh
+++ b/start.sh
@@ -295,12 +295,43 @@ chown agent:agent "$HERMES_CONFIG"
 # HERMES_HOME above). The hermes binary is on PATH via /home/agent/.local/bin
 # (set in Dockerfile) — that location is read-only under T1 sandbox but
 # binary lookup only needs read.
-# Use bash -c (not -lc) since we no longer want the login-shell HOME-driven
-# defaults; we're explicitly setting PATH + HOME inline.
-nohup gosu agent env HOME=/tmp PATH="/home/agent/.local/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin" \
-    bash -c "cd /tmp && hermes gateway" \
-    >>"$LOG_FILE" 2>&1 &
-GATEWAY_PID=$!
+# Spawn + supervisor logic lives in scripts/gateway-supervisor.sh — sourced
+# here so the function bodies are testable independently of start.sh's
+# surrounding setup. See gateway-supervisor.sh for the supervisor's
+# restart-cap + rolling-window semantics.
+# Lookup chain handles both production (Dockerfile copies start.sh to
+# /usr/local/bin/ and scripts/ to /app/scripts/) and local dev (running
+# ./start.sh from the repo root).
+# shellcheck source=scripts/gateway-supervisor.sh
+_supervisor_src=""
+_start_dir="$(cd "$(dirname "$0")" && pwd)"
+for _candidate in \
+    "${_start_dir}/scripts/gateway-supervisor.sh" \
+    "${_start_dir}/gateway-supervisor.sh" \
+    "/app/scripts/gateway-supervisor.sh" \
+    "/usr/local/bin/gateway-supervisor.sh"; do
+  if [ -f "${_candidate}" ]; then
+    _supervisor_src="${_candidate}"
+    break
+  fi
+done
+if [ -z "${_supervisor_src}" ]; then
+  echo "[start.sh] FATAL: gateway-supervisor.sh not found. Looked in ${_start_dir}/scripts/, ${_start_dir}/, /app/scripts/, /usr/local/bin/. Image misbuilt?" >&2
+  exit 1
+fi
+# shellcheck source=scripts/gateway-supervisor.sh
+. "${_supervisor_src}"
+spawn_gateway "$LOG_FILE"
+
+# --- Supervise hermes gateway in the background ---
+# Backgrounded subshell polls GATEWAY_PID and respawns on death.
+# Restart cap (default 5 in 300s) prevents tight crash-restart loops on
+# persistent failures (e.g., gateway dying immediately on every spawn
+# because of bad config). The cap is per rolling window — a single
+# transient crash early on doesn't count against a much-later one.
+supervise_gateway "$LOG_FILE" &
+SUPERVISOR_PID=$!
+echo "[start.sh] hermes gateway supervisor backgrounded (pid ${SUPERVISOR_PID}, max_restarts=${HERMES_GATEWAY_MAX_RESTARTS:-5}/${HERMES_GATEWAY_RESTART_WINDOW_SEC:-300}s)"
 
 # --- Race molecule-runtime with hermes gateway ---
 # Previously this script waited up to 120s for hermes-gateway /health


### PR DESCRIPTION
## Summary

Closes #52. Pairs with PR #51 (race start.sh).

PR #51 backgrounded \`hermes gateway\` and exec'd molecule-runtime immediately; the captured \`GATEWAY_PID\` was unused after that. A gateway crash AFTER \`adapter.setup()\` returned would leave molecule-runtime serving \`/.well-known/agent-card.json\` 200 while every JSON-RPC call silently failed (executor proxies to a dead :8642). Container only recovered on full restart.

## Fix

Repurpose \`GATEWAY_PID\` into a real supervisor.

\`scripts/gateway-supervisor.sh\` exposes:
- \`spawn_gateway <log_file>\` — nohup-spawn the gateway, set the \`GATEWAY_PID\` global. Idempotent.
- \`supervise_gateway <log_file>\` — backgrounded loop that polls \`GATEWAY_PID\` and respawns on death.

Restart cap: \`HERMES_GATEWAY_MAX_RESTARTS\` (default 5) within a rolling \`HERMES_GATEWAY_RESTART_WINDOW_SEC\` window (default 300s). Matches systemd \`Restart=\` and k8s BackOff semantics — a single transient crash early in the workspace's life doesn't count against a much-later one. Counter resets when window elapses.

\`HERMES_GATEWAY_SUPERVISOR_DISABLE=1\` escape hatch for debugging.

## Test plan

\`scripts/test-gateway-supervisor.sh\` covers:

- [x] \`spawn_gateway\` sets \`GATEWAY_PID\` to a live process
- [x] \`HERMES_GATEWAY_SUPERVISOR_DISABLE=1\` short-circuits in <2s
- [x] supervisor respawns gateway when it dies, within cap (verified via stderr log assertion + dead-pid check)
- [x] supervisor exits cleanly after exceeding cap (\"exceeded N restarts\" log line, total wall clock <15s)

Pure bash, mocked \`gosu\`/\`hermes\` binaries via PATH-prepended shims, no bats/pytest dependencies — same convention as \`scripts/test-derive-provider.sh\`. Wired into \`.github/workflows/ci.yml\` shell-tests job.

## Bench impact

None expected. The supervisor is a 5s polling sleep in a backgrounded subshell — no impact on cold-start. RFC #388 \`bench-provision-time\` hermes was 46.2s on the AMI baked from PR #51 today; this PR doesn't change that path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)